### PR TITLE
Adding support for module level execution

### DIFF
--- a/showyourwork/__main__.py
+++ b/showyourwork/__main__.py
@@ -1,0 +1,3 @@
+from showyourwork.cli import entry_point
+
+entry_point()


### PR DESCRIPTION
This PR adds support for executing the showyourwork CLI using the following syntax

```bash
python -m showyourwork ...
```

taking the same arguments as the script-like

```bash
showyourwork ...
```

version. This can be useful for environments with path collisions, and I just pretty much always like to run Python scripts this way to make sure that I know which Python installation they are using. 