### PR TITLE
change docs on manuscript name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -253,7 +253,7 @@ Finally, dependencies of the manuscript file are also allowed:
 .. _config.ms:
 
 ``ms_name``
-^^^^^^
+^^^^^^^^^^^
 
 **Type:** ``str``
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -252,7 +252,7 @@ Finally, dependencies of the manuscript file are also allowed:
 
 .. _config.ms:
 
-``ms``
+``ms_name``
 ^^^^^^
 
 **Type:** ``str``
@@ -265,13 +265,13 @@ in the repository root) .
 
 **Required:** no
 
-**Default:** ``src/tex/ms.tex``
+**Default:** ``ms``
 
 **Example:**
 
 .. code-block:: yaml
 
-  ms: src/tex/article.tex
+  ms_name: article
 
 
 .. _config.overleaf:


### PR DESCRIPTION
fix for https://github.com/showyourwork/showyourwork/issues/104#issuecomment-1148946514

I effectively just changed `ms` to `ms_name`. I also changed the default value on what is coded in `config.py`, i.e., `src/text/ms.tex` is just `ms`.