### PR TITLE
Added docs about using LaTeX fonts in matplotlib.

### DIFF
--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -219,6 +219,21 @@ To save some typing, you could instead add this boilerplate to the
 these commands get executed whenever that file is imported into your scripts.
 
 
+Using LaTeX fonts in matplotlib without installing LaTeX
+--------------------------------------------------------
+
+If you just want ``matplotlib`` to use Computer Modern fonts so that the font in your plots matches the font in your manuscript, you can accomplish this without the full LaTeX installation described above.
+Just add the following lines to ``src/scripts/matplotlibrc``:
+
+.. code-block:: python
+  
+    # set font to match LaTeX's Computer Modern
+    font.family: serif
+    font.serif: cmr10
+    mathtext.fontset: cm
+    axes.formatter.use_mathtext: True # needed when using cm=cmr10 for normal text
+
+
 Using LaTeX Workshop in VSCode
 ------------------------------
 


### PR DESCRIPTION
I added a little section to the FAQ about how you can easily get `matplotlib` to use Computer Modern fonts, so that the font in your plots matches the font in your manuscript.

Not sure if you want this added, since it's more of a `matplotlib` tip than a `showyourwork` tip. However, I personally only use `usetex: True` so that my fonts will match, but seeing as `usetex: True` is a little complicated with `showyourwork`, it might be nice to point to this quick workaround.

But again, I won't be offended if you decide this isn't appropriate for the `showyourwork` docs!