### PR TITLE
Enable YAML parsing without LibYAML

### DIFF
--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -10,6 +10,11 @@ import filecmp
 import jinja2
 from pathlib import Path
 import re
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    # If LibYAML not installed
+    from yaml import Loader, Dumper
 
 
 def run_in_env(command, **kwargs):
@@ -73,7 +78,7 @@ def run_in_env(command, **kwargs):
         jinja2.Environment(loader=jinja2.FileSystemLoader(paths.user().repo))
         .get_template("showyourwork.yml")
         .render(),
-        Loader=yaml.CLoader,
+        Loader=Loader,
     )
     syw_spec = user_config.get("version", None)
     if not syw_spec:
@@ -102,12 +107,12 @@ def run_in_env(command, **kwargs):
     # and add the user's requested showyourwork version as a dependency
     # so we can import it within Snakemake
     with open(syw_envfile, "r") as f:
-        syw_env = yaml.load(f, Loader=yaml.CLoader)
+        syw_env = yaml.load(f, Loader=Loader)
     for dep in syw_env["dependencies"]:
         if type(dep) is dict and "pip" in dep:
             dep["pip"].append(syw_spec)
     with open(workflow_envfile, "w") as f:
-        print(yaml.dump(syw_env, Dumper=yaml.CDumper), file=f)
+        print(yaml.dump(syw_env, Dumper=Dumper), file=f)
 
     # Set up or update our isolated conda env
     if not paths.user().env.exists():

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -7,6 +7,11 @@ import re
 import sys
 import jinja2
 import yaml
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    # If LibYAML not installed
+    from yaml import Loader, Dumper
 
 try:
     import snakemake
@@ -23,14 +28,14 @@ def edit_yaml(file):
     """
     if Path(file).exists():
         with open(file, "r") as f:
-            contents = yaml.load(f, Loader=yaml.CLoader)
+            contents = yaml.load(f, Loader=Loader)
     else:
         contents = {}
     try:
         yield contents
     finally:
         with open(file, "w") as f:
-            print(yaml.dump(contents, Dumper=yaml.CDumper), file=f)
+            print(yaml.dump(contents, Dumper=Dumper), file=f)
 
 
 def render_config(cwd="."):


### PR DESCRIPTION
This allows PyYAML to work even without LibYAML installed. This fallback seems to be the recommended import strategy according to the pyyaml website: https://pyyaml.org/wiki/PyYAMLDocumentation

---

This fixes an issue I was seeing with LibYAML not getting installed (perhaps it is not available on my M1 mac). Anyways, this modification fixed it.
```python
  File "/Users/mcranmer/venvs/main/bin/showyourwork", line 8, in <module>
    sys.exit(entry_point())
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/showyourwork/cli/main.py", line 92, in build
    commands.preprocess()
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/showyourwork/cli/commands/preprocess.py", line 16, in preprocess
    result = run_in_env(command, check=False)
  File "/Users/mcranmer/venvs/main/lib/python3.8/site-packages/showyourwork/cli/conda_env.py", line 77, in run_in_env
    Loader=yaml.CLoader,
AttributeError: module 'yaml' has no attribute 'CLoader
```