### PR TITLE
Remove imports of `fontspec` package to fix tt fonts

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -43,19 +43,9 @@
 \newcommand\script[1]{}
 
 % Showyourwork logo
-% We can only use our custom font if running XeTeX / LuaTeX
-\ifxetex
-  \usepackage{fontspec}
-  \defaultfontfeatures{Extension = .otf}
-  \newfontfamily\ShowYourWorkFont{showyourwork.otf}
-  \newcommand{\showyourwork}{%
-    {\ShowYourWorkFont\color{red}\smash{show your work!}}\xspace
-  }
-\else
-  \newcommand{\showyourwork}{%
-      \smash{\raisebox{-1.6ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
-  }
-\fi
+\newcommand{\showyourwork}{%
+    \smash{\raisebox{-1.6ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
+}
 
 % Generic: replace \LaTeX with \Latex + showyourwork in \maketitle
 \let\oldmaketitle\maketitle

--- a/showyourwork/workflow/resources/styles/preprocess.tex
+++ b/showyourwork/workflow/resources/styles/preprocess.tex
@@ -4,10 +4,6 @@
 \RequirePackage{hyperref} % url links
 \RequirePackage{suffix} % allows definition of starred commmands
 \RequirePackage{ifxetex}
-\ifxetex
-  \RequirePackage{fontspec}
-  \defaultfontfeatures{Extension = .otf}
-\fi
 \RequirePackage{fontawesome5} % FontAwesome symbols
 \RequirePackage{letltxmacro} % command redefinitions
 \RequirePackage{xstring} % string manipulation


### PR DESCRIPTION
This should in principle fix the use of custom typewriter fonts when compiling with `tectonic`. @rodluger 