### PR TITLE
Relaxing conda channel settings

### DIFF
--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
@@ -1,6 +1,3 @@
-channels:
-  - defaults
-  - conda-forge
 dependencies:
   - numpy=1.19.2
   - pip=21.0.1

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -1,14 +1,10 @@
-channels:
-  - defaults
-  - conda-forge
-  - bioconda
 dependencies:
   - python=3.9
   - pip=21.0.1
-  - tectonic=0.8.0
-  - mamba=0.23.3
-  - snakemake-minimal=6.15.5
-  - imagemagick
+  - conda-forge::tectonic=0.8.0
+  - conda-forge::mamba=0.23.3
+  - bioconda::snakemake-minimal=6.15.5
+  - conda-forge::imagemagick
   - graphviz
   - pip:
       - click==8.0.4


### PR DESCRIPTION
The `defaults` conda channel is pretty trash for M1 macs and the default syw environments don't play nice with my setup (i.e. conda says it can't solve the requested dependencies). Removing the channel list and specifying the channels only when necessary while falling back on the system settings for the others works well for me and I don't think we lose anything with this change!