### PR TITLE
Adding option to use a fork of showyourwork

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -739,7 +739,7 @@ crank up the verbosity even more by passing the ``--verbose`` argument to
 ``version``
 ^^^^^^^^^^^
 
-**Type:** ``str``
+**Type:** ``str`` or ``mapping``
 
 **Description:** The version of the |showyourwork| package required to build
 the article, populated automatically when ``showyouwork setup`` is run. Users
@@ -748,6 +748,7 @@ package. Options are:
 
 - any pip-installable version number (e.g., ``0.3.0``)
 - a 5-character (short) or 40-character (long) GitHub commit SHA (e.g, ``abcde``) corresponding to a specific commit to the `showyourwork/showyourwork <https://github.com/showyourwork/showyourwork>`_ repo
+- a mapping with the ``fork`` and/or ``spec`` keys described below
 
 **Required:** yes
 
@@ -756,3 +757,44 @@ package. Options are:
 .. code-block:: yaml
 
   version: 0.3.0
+
+.. _config.version_fork:
+
+``version.fork``
+^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** The URL of a GitHub fork of the |showyourwork| repo.
+
+**Required:** no
+
+**Default:** ``https://github.com/showyourwork/showyourwork.git``
+
+**Example:**
+
+.. code-block:: yaml
+
+  verbose:
+    fork: https://github.com/SOMEUSER/showyourwork.git
+
+.. _config.version_spec:
+
+``version.spec``
+^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** The spec for a specific branch, tag, or commit on the fork of
+the |showyourwork| repo specified by ``version.fork``.
+
+**Required:** no
+
+**Default:** ``null``
+
+**Example:**
+
+.. code-block:: yaml
+
+  verbose:
+    spec: main

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -739,16 +739,19 @@ crank up the verbosity even more by passing the ``--verbose`` argument to
 ``version``
 ^^^^^^^^^^^
 
-**Type:** ``str`` or ``mapping``
+**Type:** ``mapping`` (or ``str``)
 
 **Description:** The version of the |showyourwork| package required to build
 the article, populated automatically when ``showyouwork setup`` is run. Users
-may, however, change this to upgrade/downgrade to a different version of the
-package. Options are:
+may change this to upgrade/downgrade to a different version of the
+package. Please see the nested keys (``pip``, ``path``, ``fork``, and ``ref``)
+below for information on how to specify an exact version.
+
+For backwards compatibility, the ``version`` option also accepts a string
+corresponding to:
 
 - any pip-installable version number (e.g., ``0.3.0``)
 - a 5-character (short) or 40-character (long) GitHub commit SHA (e.g, ``abcde``) corresponding to a specific commit to the `showyourwork/showyourwork <https://github.com/showyourwork/showyourwork>`_ repo
-- a mapping with the nested keys (``pip``, ``path``, ``fork``, and ``ref``) described below
 
 **Required:** yes
 
@@ -784,7 +787,9 @@ package. Options are:
 **Type:** ``str``
 
 **Description:** A relative (to the project repository root) or absolute path to
-a local version of |showyourwork|.
+a local version of |showyourwork|. Note that this should only be used during
+development, since third-party users of your workflow may not have |showyourwork|
+installed in the same path locally!
 
 **Required:** no
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -758,6 +758,43 @@ package. Options are:
 
   version: 0.3.0
 
+.. _config.version_pip:
+
+``version.pip``
+^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A version number for |showyourwork| that is available on PyPI.
+
+**Required:** no
+
+**Example:**
+
+.. code-block:: yaml
+
+  version:
+    pip: 0.3.0
+
+.. _config.version_path:
+
+``version.path``
+^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A relative (to the project repository root) or absolute path to
+a local version of |showyourwork|.
+
+**Required:** no
+
+**Example:**
+
+.. code-block:: yaml
+
+  version:
+    path: ./local/version/of/showyourwork
+
 .. _config.version_fork:
 
 ``version.fork``
@@ -765,7 +802,7 @@ package. Options are:
 
 **Type:** ``str``
 
-**Description:** The URL of a GitHub fork of the |showyourwork| repo.
+**Description:** The URL of a fork of the |showyourwork| repo.
 
 **Required:** no
 
@@ -778,14 +815,14 @@ package. Options are:
   version:
     fork: https://github.com/SOMEUSER/showyourwork.git
 
-.. _config.version_spec:
+.. _config.version_ref:
 
-``version.spec``
-^^^^^^^^^^^^^^^^
+``version.ref``
+^^^^^^^^^^^^^^^
 
 **Type:** ``str``
 
-**Description:** The spec for a specific branch, tag, or commit on the fork of
+**Description:** The name of a specific branch, tag, or commit on the fork of
 the |showyourwork| repo specified by ``version.fork``.
 
 **Required:** no
@@ -797,4 +834,4 @@ the |showyourwork| repo specified by ``version.fork``.
 .. code-block:: yaml
 
   version:
-    spec: main
+    ref: main

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -775,7 +775,7 @@ package. Options are:
 
 .. code-block:: yaml
 
-  verbose:
+  version:
     fork: https://github.com/SOMEUSER/showyourwork.git
 
 .. _config.version_spec:
@@ -796,5 +796,5 @@ the |showyourwork| repo specified by ``version.fork``.
 
 .. code-block:: yaml
 
-  verbose:
+  version:
     spec: main

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -748,7 +748,7 @@ package. Options are:
 
 - any pip-installable version number (e.g., ``0.3.0``)
 - a 5-character (short) or 40-character (long) GitHub commit SHA (e.g, ``abcde``) corresponding to a specific commit to the `showyourwork/showyourwork <https://github.com/showyourwork/showyourwork>`_ repo
-- a mapping with the ``fork`` and/or ``spec`` keys described below
+- a mapping with the nested keys (``pip``, ``path``, ``fork``, and ``ref``) described below
 
 **Required:** yes
 

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -149,9 +149,9 @@ def parse_syw_spec(syw_spec):
         if re.match(r"(?:(\d+\.[.\d]*\d+))", syw_spec):
             syw_spec = {"pip": syw_spec}
         elif re.match("[0-9a-f]{5,40}", syw_spec):
-            syw_spec = {"sha": syw_spec}
+            syw_spec = {"ref": syw_spec}
         elif syw_spec in ["main", "dev"]:
-            syw_spec = {"branch": syw_spec}
+            syw_spec = {"ref": syw_spec}
         else:
             syw_spec = {"path": syw_spec}
 
@@ -170,9 +170,7 @@ def parse_syw_spec(syw_spec):
     fork = syw_spec.get(
         "fork", "https://github.com/showyourwork/showyourwork.git"
     )
-    spec = syw_spec.get(
-        "branch", syw_spec.get("tag", syw_spec.get("sha", None))
-    )
+    spec = syw_spec.get("ref", None)
     if not spec:
         return f"git+{fork}#egg=showyourwork"
     else:

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -10,6 +10,7 @@ import filecmp
 import jinja2
 from pathlib import Path
 import re
+
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
@@ -80,28 +81,7 @@ def run_in_env(command, **kwargs):
         .render(),
         Loader=Loader,
     )
-    syw_spec = user_config.get("version", None)
-    if not syw_spec:
-        # No specific version provided; default to any
-        syw_spec = "showyourwork"
-    elif re.match(r"(?:(\d+\.[.\d]*\d+))", syw_spec):
-        # This is an actual package version
-        syw_spec = f"showyourwork=={syw_spec}"
-    elif re.match("[0-9a-f]{5,40}", syw_spec):
-        # This is a commit SHA
-        syw_spec = f"git+https://github.com/showyourwork/showyourwork.git@{syw_spec}#egg=showyourwork"
-    elif syw_spec in ["main", "dev"]:
-        # This is a branch on github
-        syw_spec = f"git+https://github.com/showyourwork/showyourwork.git@{syw_spec}#egg=showyourwork"
-    else:
-        # Assume it's a local path to the package
-        if not Path(syw_spec).is_absolute():
-            syw_spec = (paths.user().repo / syw_spec).resolve()
-        else:
-            syw_spec = Path(syw_spec).resolve()
-        if not syw_spec.exists():
-            raise exceptions.ShowyourworkNotFoundError(syw_spec)
-        syw_spec = f"-e {syw_spec}"
+    syw_spec = parse_syw_spec(user_config.get("version", None))
 
     # Copy the showyourwork environment file to a temp location,
     # and add the user's requested showyourwork version as a dependency
@@ -156,3 +136,39 @@ def run_in_env(command, **kwargs):
         shell=True,
         **kwargs,
     )
+
+
+def parse_syw_spec(syw_spec):
+    if not syw_spec:
+        # No specific version provided; default to any
+        syw_spec = "showyourwork"
+    elif isinstance(syw_spec, str):
+        if re.match(r"(?:(\d+\.[.\d]*\d+))", syw_spec):
+            # This is an actual package version
+            syw_spec = f"showyourwork=={syw_spec}"
+        elif re.match("[0-9a-f]{5,40}", syw_spec):
+            # This is a commit SHA
+            syw_spec = f"git+https://github.com/showyourwork/showyourwork.git@{syw_spec}#egg=showyourwork"
+        elif syw_spec in ["main", "dev"]:
+            # This is a branch on github
+            syw_spec = f"git+https://github.com/showyourwork/showyourwork.git@{syw_spec}#egg=showyourwork"
+        else:
+            # Assume it's a local path to the package
+            if not Path(syw_spec).is_absolute():
+                syw_spec = (paths.user().repo / syw_spec).resolve()
+            else:
+                syw_spec = Path(syw_spec).resolve()
+            if not syw_spec.exists():
+                raise exceptions.ShowyourworkNotFoundError(syw_spec)
+            syw_spec = f"-e {syw_spec}"
+    else:
+        fork = syw_spec.get(
+            "fork", "https://github.com/showyourwork/showyourwork.git"
+        )
+        spec = syw_spec.get("spec", None)
+        if not spec:
+            syw_spec = f"git+{fork}#egg=showyourwork"
+        else:
+            syw_spec = f"git+{fork}@{spec}#egg=showyourwork"
+
+    return syw_spec

--- a/tests/test_parse_syw_spec.py
+++ b/tests/test_parse_syw_spec.py
@@ -22,7 +22,7 @@ from showyourwork.cli.conda_env import parse_syw_spec
         ),
         ({"pip": "0.3.0"}, "showyourwork==0.3.0"),
         (
-            {"branch": "branch"},
+            {"ref": "branch"},
             "git+https://github.com/showyourwork/showyourwork.git@branch#egg=showyourwork",
         ),
         (
@@ -30,17 +30,9 @@ from showyourwork.cli.conda_env import parse_syw_spec
             "git+https://github.com/dfm/showyourwork#egg=showyourwork",
         ),
         (
-            {"sha": "893eda2"},
-            "git+https://github.com/showyourwork/showyourwork.git@893eda2#egg=showyourwork",
-        ),
-        (
-            {"tag": "v0.3.0"},
-            "git+https://github.com/showyourwork/showyourwork.git@v0.3.0#egg=showyourwork",
-        ),
-        (
             {
                 "fork": "https://github.com/dfm/showyourwork",
-                "branch": "branch",
+                "ref": "branch",
             },
             "git+https://github.com/dfm/showyourwork@branch#egg=showyourwork",
         ),

--- a/tests/test_parse_syw_spec.py
+++ b/tests/test_parse_syw_spec.py
@@ -20,8 +20,9 @@ from showyourwork.cli.conda_env import parse_syw_spec
             "main",
             "git+https://github.com/showyourwork/showyourwork.git@main#egg=showyourwork",
         ),
+        ({"pip": "0.3.0"}, "showyourwork==0.3.0"),
         (
-            {"spec": "branch"},
+            {"branch": "branch"},
             "git+https://github.com/showyourwork/showyourwork.git@branch#egg=showyourwork",
         ),
         (
@@ -29,9 +30,17 @@ from showyourwork.cli.conda_env import parse_syw_spec
             "git+https://github.com/dfm/showyourwork#egg=showyourwork",
         ),
         (
+            {"sha": "893eda2"},
+            "git+https://github.com/showyourwork/showyourwork.git@893eda2#egg=showyourwork",
+        ),
+        (
+            {"tag": "v0.3.0"},
+            "git+https://github.com/showyourwork/showyourwork.git@v0.3.0#egg=showyourwork",
+        ),
+        (
             {
                 "fork": "https://github.com/dfm/showyourwork",
-                "spec": "branch",
+                "branch": "branch",
             },
             "git+https://github.com/dfm/showyourwork@branch#egg=showyourwork",
         ),

--- a/tests/test_parse_syw_spec.py
+++ b/tests/test_parse_syw_spec.py
@@ -1,6 +1,7 @@
 import pytest
 
 from showyourwork.cli.conda_env import parse_syw_spec
+from showyourwork.exceptions import ShowyourworkException
 
 
 @pytest.mark.parametrize(
@@ -36,7 +37,19 @@ from showyourwork.cli.conda_env import parse_syw_spec
             },
             "git+https://github.com/dfm/showyourwork@branch#egg=showyourwork",
         ),
+        (
+            {"invalid": "value"},
+            "raise",
+        ),
+        (
+            {"pip": "0.3.0", "ref": "main"},
+            "raise",
+        ),
     ],
 )
 def test_parse_syw_spec(spec, expected):
-    assert parse_syw_spec(spec) == expected
+    if expected == "raise":
+        with pytest.raises(ShowyourworkException):
+            parse_syw_spec(spec)
+    else:
+        assert parse_syw_spec(spec) == expected

--- a/tests/test_parse_syw_spec.py
+++ b/tests/test_parse_syw_spec.py
@@ -1,0 +1,41 @@
+import pytest
+
+from showyourwork.cli.conda_env import parse_syw_spec
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        (None, "showyourwork"),
+        ("0.3.0", "showyourwork==0.3.0"),
+        (
+            "893eda2",
+            "git+https://github.com/showyourwork/showyourwork.git@893eda2#egg=showyourwork",
+        ),
+        (
+            "893eda204de56455002e5ef2d1d49e0b7349d37a",
+            "git+https://github.com/showyourwork/showyourwork.git@893eda204de56455002e5ef2d1d49e0b7349d37a#egg=showyourwork",
+        ),
+        (
+            "main",
+            "git+https://github.com/showyourwork/showyourwork.git@main#egg=showyourwork",
+        ),
+        (
+            {"spec": "branch"},
+            "git+https://github.com/showyourwork/showyourwork.git@branch#egg=showyourwork",
+        ),
+        (
+            {"fork": "https://github.com/dfm/showyourwork"},
+            "git+https://github.com/dfm/showyourwork#egg=showyourwork",
+        ),
+        (
+            {
+                "fork": "https://github.com/dfm/showyourwork",
+                "spec": "branch",
+            },
+            "git+https://github.com/dfm/showyourwork@branch#egg=showyourwork",
+        ),
+    ],
+)
+def test_parse_syw_spec(spec, expected):
+    assert parse_syw_spec(spec) == expected


### PR DESCRIPTION
I think that this should be backwards compatible, but it permits the following syntax:

```yaml
version:
  fork: https://github.com/dfm/showyourwork.git
  spec: some-branch-tag-or-commit-hash
```

Omitting the `spec` argument will use the default branch, and omitting the `fork` argument will use the base `showyourwork/showyourwork` repo.

Ref: #145 for some context