### PR TITLE
Reorganize test workflows a little

### DIFF
--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -1,4 +1,4 @@
-name: local integration tests
+name: local tests
 
 on:
   push:

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: local integration tests
 
 on:
   push:
@@ -8,35 +8,9 @@ on:
   pull_request:
 
 jobs:
-  unit:
+  tests:
     runs-on: ubuntu-latest
-    name: Run unit tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Set up python
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: "3.9"
-
-      - name: Install showyourwork
-        shell: bash -l {0}
-        run: |
-          python -m pip install -U pip
-          python -m pip install -e ".[tests]"
-
-      - name: Run tests
-        shell: bash -l {0}
-        run: python -m pytest tests/unit
-
-  integration:
-    runs-on: ubuntu-latest
-    name: Run integration tests
+    name: Run local integration tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: publish
+
 on:
   release:
     types:

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -1,4 +1,4 @@
-name: remote integration tests
+name: remote tests
 
 on:
   push:

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -1,4 +1,4 @@
-name: integration
+name: remote integration tests
 
 on:
   push:
@@ -9,8 +9,18 @@ on:
     types: [labeled]
 
 jobs:
-  remote:
-    if: ${{ (github.event_name == 'push' && github.repository == 'showyourwork/showyourwork') || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test')) }}
+  tests:
+    if: |
+      ${{
+        (
+          github.event_name == 'push' &&
+          github.repository == 'showyourwork/showyourwork'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          contains(github.event.pull_request.labels.*.name, 'safe to test')
+        )
+      }}
     runs-on: ubuntu-latest
     name: Run remote integration tests
     concurrency: showyourwork-remote
@@ -44,3 +54,14 @@ jobs:
           GH_API_KEY: ${{ secrets.GH_API_KEY }}
           SHOWYOURWORK_FORK: ${{ github.event.pull_request.head.repo.clone_url }}
           SHOWYOURWORK_REF: ${{ github.event.pull_request.head.sha }}
+
+  skipped:
+    needs: tests
+    runs-on: ubuntu-latest
+    name: Remote integration tests were skipped
+    if: needs.tests.result == 'skipped'
+    steps:
+      - name: Info
+        shell: bash -l {0}
+        run: |
+          echo "::warning ::Remote integration tests were skipped. These can only run on the showyourwork/showyourwork repo and require admin privileges."

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -44,14 +44,3 @@ jobs:
           GH_API_KEY: ${{ secrets.GH_API_KEY }}
           SHOWYOURWORK_FORK: ${{ github.event.pull_request.head.repo.clone_url }}
           SHOWYOURWORK_REF: ${{ github.event.pull_request.head.sha }}
-
-  skipped:
-    needs: tests
-    runs-on: ubuntu-latest
-    name: Remote integration tests were skipped
-    if: needs.tests.result == 'skipped'
-    steps:
-      - name: Info
-        shell: bash -l {0}
-        run: |
-          echo "::warning ::Remote integration tests were skipped. These can only run on the showyourwork/showyourwork repo and require admin privileges."

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -10,17 +10,7 @@ on:
 
 jobs:
   tests:
-    if: |
-      ${{
-        (
-          github.event_name == 'push' &&
-          github.repository == 'showyourwork/showyourwork'
-        ) ||
-        (
-          github.event_name == 'pull_request_target' &&
-          contains(github.event.pull_request.labels.*.name, 'safe to test')
-        )
-      }}
+    if: ${{ (github.event_name == 'push' && github.repository == 'showyourwork/showyourwork') || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test')) }}
     runs-on: ubuntu-latest
     name: Run remote integration tests
     concurrency: showyourwork-remote

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,35 @@
+name: unit tests
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    name: Run unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up python
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: "3.9"
+
+      - name: Install showyourwork
+        shell: bash -l {0}
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e ".[tests]"
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: python -m pytest tests/unit

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,6 @@
 .. :changelog:
 
-0.3.1 (TBD)
+0.3.1 (2022-08-19)
 ++++++++++++++++++
 
 - Fixed bug related to displaying figure caption icons for cached datasets.
@@ -35,6 +35,13 @@
   logo is no longer displayed as text in a custom font, but as a PDF image.
 - Fix for newer versions of ``git`` that use ``main`` as the default branch name, which
   led to errors when integrating with Overleaf (which uses ``master``).
+- Revamped the way tests for the `showyourwork/showyourwork <https://github.com/showyourwork/showyourwork>`__
+  repo are run. Split tests into unit tests, local integration tests, and remote
+  integration tests. The first two can be executed on either the base repo or
+  any fork; the last one can only be executed on the base repo or upon the
+  ``pull_request_target`` trigger from a PR, which occurs when a PR is labeled
+  ``safe to test`` by a maintainer. This change will make contributing to
+  ``showyourwork`` much easier going forward!
 - Changed the syntax for specifying the ``showyourwork`` version number in the
   ``showyourwork.yml`` config file. Users should now specify whether the version
   spec is a ``pip``-installable version, a ``path`` to a local installation,

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
     </a>
     <br/>
     <a href="https://github.com/showyourwork/showyourwork/actions/workflows/tests.yml">
-        <img src="https://github.com/showyourwork/showyourwork/actions/workflows/tests.yml/badge.svg" alt="tests"/>
+        <img src="https://github.com/showyourwork/showyourwork/actions/workflows/unit_tests.yml/badge.svg" alt="unit tests"/>
     </a>
-    <a href="https://github.com/showyourwork/showyourwork/actions/workflows/integration.yml">
-        <img src="https://github.com/showyourwork/showyourwork/actions/workflows/integration.yml/badge.svg" alt="tests"/>
+    <a href="https://github.com/showyourwork/showyourwork/actions/workflows/local_integration_tests.yml">
+        <img src="https://github.com/showyourwork/showyourwork/actions/workflows/local_integration_tests.yml/badge.svg" alt="local integration tests"/>
+    </a>
+    <a href="https://github.com/showyourwork/showyourwork/actions/workflows/remote_integration_tests.yml">
+        <img src="https://github.com/showyourwork/showyourwork/actions/workflows/remote_integration_tests.yml/badge.svg" alt="remote integration tests"/>
     </a>
     <a href="https://showyourwork.readthedocs.io">
         <img src="https://img.shields.io/static/v1?label=read&message=the%20docs&color=blue" alt="tests"/>


### PR DESCRIPTION
Separates unit tests, local integration tests, and remote integration tests into their own ``.yml`` workflow files to make it a bit easier for devs to understand what's going on.