### PR TITLE
Replace marginnote with marginpar

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -3,14 +3,12 @@
 \RequirePackage{xcolor} % custom colors
 \RequirePackage{hyperref} % url links
 \RequirePackage{suffix} % allows definition of starred commmands
-\RequirePackage{ifxetex}
 \RequirePackage{fontawesome5} % FontAwesome symbols
 \RequirePackage{letltxmacro} % command redefinitions
 \RequirePackage{xstring} % string manipulation
 \RequirePackage{catchfile} % read file into macro
 \RequirePackage{totcount} % count total number of errors
 \RequirePackage[notref, notcite]{showkeys} % get label refs
-\RequirePackage{marginnote} % margin notes
 \RequirePackage{xspace} % better spacing after icons
 \RequirePackage{graphicx} % includegraphics
 \RequirePackage{stackengine} % stacking figure links
@@ -139,7 +137,7 @@
   %\ifcsname if@two@col\endcsname%
   %\if@two@col\setlength{\marginparsep}{-45pt}\fi%
   %\fi%
-  \marginnote{%
+  \marginpar{%
     \href{\syw@url/tree/\syw@sha/}{%
       \color{sywBlue}%
       \faGithub%

--- a/showyourwork/workflow/resources/styles/preprocess.tex
+++ b/showyourwork/workflow/resources/styles/preprocess.tex
@@ -3,14 +3,12 @@
 \RequirePackage{xcolor} % custom colors
 \RequirePackage{hyperref} % url links
 \RequirePackage{suffix} % allows definition of starred commmands
-\RequirePackage{ifxetex}
 \RequirePackage{fontawesome5} % FontAwesome symbols
 \RequirePackage{letltxmacro} % command redefinitions
 \RequirePackage{xstring} % string manipulation
 \RequirePackage{catchfile} % read file into macro
 \RequirePackage{totcount} % count total number of errors
 \RequirePackage[notref, notcite]{showkeys} % get label refs
-\RequirePackage{marginnote} % margin notes
 \RequirePackage{xspace} % better spacing after icons
 \RequirePackage{graphicx} % includegraphics
 


### PR DESCRIPTION
I think we can safely use the built-in `\marginpar` instead of `\marginnote`, which would circumvent the issues we have with `\marginnote` being defined by other packages (c.f. #133 #144). We only use this command to place the abstract icon, and it looks like the formatting is unchanged by switching to `\marginpar`. For some reason I thought that `showkeys` relied on `marginnote` but that doesn't seem to be the case, so this is (I think) an extremely trivial change that might fix all our issues.

@dfm Can you give this a spin with ARAA?

Fixes #153.