### PR TITLE
Check if figure, abstract defined before redefining them

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -12,6 +12,7 @@
 \RequirePackage{xspace} % better spacing after icons
 \RequirePackage{graphicx} % includegraphics
 \RequirePackage{stackengine} % stacking figure links
+\RequirePackage{etoolbox} % ifcsmacro
 
 % Is this running on GitHub Actions?
 \newif\ifOnGithubActions
@@ -147,29 +148,26 @@
     \oldendabstract%
   }
 }{%
-  \renewenvironment{abstract}{%
-    \oldabstract%
-  }{%
-    % AASTex631 hack to reduce margin separation
-    % in the abstract of a two-column document
-    %\ifcsname if@two@col\endcsname%
-    %\if@two@col\setlength{\marginparsep}{-45pt}\fi%
-    %\fi%
-    \marginpar{%
-      \href{\syw@url/tree/\syw@sha/}{%
-        \color{sywBlue}%
-        \faGithub%
-      }%
-      \ifOnGithubActions
-        \hspace{3pt}%
-        \href{\syw@url/actions/runs/\syw@runid/}{%
-          \color{sywGreen}%
-          \faCheckCircle%
+  \ifcsmacro{abstract}{%
+    \renewenvironment{abstract}{%
+      \oldabstract%
+    }{%
+      \marginpar{%
+        \href{\syw@url/tree/\syw@sha/}{%
+          \color{sywBlue}%
+          \faGithub%
         }%
-      \fi
+        \ifOnGithubActions
+          \hspace{3pt}%
+          \href{\syw@url/actions/runs/\syw@runid/}{%
+            \color{sywGreen}%
+            \faCheckCircle%
+          }%
+        \fi
+      }%
+      \oldendabstract%
     }%
-    \oldendabstract%
-  }
+  }{}%
 }
 
 % Figure script icon

--- a/showyourwork/workflow/resources/styles/preprocess.tex
+++ b/showyourwork/workflow/resources/styles/preprocess.tex
@@ -11,6 +11,7 @@
 \RequirePackage[notref, notcite]{showkeys} % get label refs
 \RequirePackage{xspace} % better spacing after icons
 \RequirePackage{graphicx} % includegraphics
+\RequirePackage{etoolbox} % ifcsmacro
 
 % Logging
 \newwrite\syw@LogFile
@@ -41,44 +42,50 @@
 }
 
 % Log figures
-\let\oldfigure\figure
-\let\oldendfigure\endfigure
-\renewenvironment{figure}{%
-  \syw@LogMessage{<FIGURE>}%
-  \oldfigure%
-}{%
-  \oldendfigure%
-  \syw@LogMessage{</FIGURE>}%
-}
-\renewenvironment{figure*}{%
-  \syw@LogMessage{<FIGURE>}%
-  \oldfigure%
-}{%
-  \oldendfigure%
-  \syw@LogMessage{</FIGURE>}%
-}
+\ifcsmacro{figure}{
+  \let\oldfigure\figure
+  \let\oldendfigure\endfigure
+  \renewenvironment{figure}{%
+    \syw@LogMessage{<FIGURE>}%
+    \oldfigure%
+  }{%
+    \oldendfigure%
+    \syw@LogMessage{</FIGURE>}%
+  }
+  \renewenvironment{figure*}{%
+    \syw@LogMessage{<FIGURE>}%
+    \oldfigure%
+  }{%
+    \oldendfigure%
+    \syw@LogMessage{</FIGURE>}%
+  }
+}{}
 
 % Log equations
-\let\oldalign\align
-\let\oldendalign\endalign
-\renewenvironment{align}{%
-  \syw@LogMessage{<ALIGN>}%
-  \oldalign%
-}{%
-  \oldendalign%
-  \syw@LogMessage{</ALIGN>}%
-}
-\renewenvironment{align*}{%
-  \syw@LogMessage{<ALIGN>}%
-  \oldalign%
-}{%
-  \oldendalign%
-  \syw@LogMessage{</ALIGN>}%
-}
+\ifcsmacro{align}{
+  \let\oldalign\align
+  \let\oldendalign\endalign
+  \renewenvironment{align}{%
+    \syw@LogMessage{<ALIGN>}%
+    \oldalign%
+  }{%
+    \oldendalign%
+    \syw@LogMessage{</ALIGN>}%
+  }
+  \renewenvironment{align*}{%
+    \syw@LogMessage{<ALIGN>}%
+    \oldalign%
+  }{%
+    \oldendalign%
+    \syw@LogMessage{</ALIGN>}%
+  }
+}{}
 
 % Log figure captions
-\renewcommand{\caption}{%
-  \syw@LogMessage{<CAPTION />}%
+\ifcsmacro{caption}{
+  \renewcommand{\caption}{%
+    \syw@LogMessage{<CAPTION />}%
+  }
 }
 
 % Log graphics

--- a/tests/integration/test_letter.py
+++ b/tests/integration/test_letter.py
@@ -1,0 +1,20 @@
+from helpers import TemporaryShowyourworkRepository
+
+
+class TestLetter(TemporaryShowyourworkRepository):
+    """Test setting up and building an article that uses the basic `letter` documentclass."""
+
+    # No need to test this on CI
+    local_build_only = True
+
+    ms = r"""
+\documentclass{letter}
+\usepackage{showyourwork}
+\begin{document}
+This is a test of the standard letter class.
+\end{document}
+    """
+
+    def customize(self):
+        with open(self.cwd / "src" / "tex" / "ms.tex", "w") as f:
+            f.write(self.ms)


### PR DESCRIPTION
Fixes #178 so we can use `showyourwork` with (potentially) any documentclass.