### PR TITLE
CLI error message tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ junit
 **/sitecustomize.py
 dist/*
 .vscode
+build

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -195,7 +195,7 @@ def validate_slug(context, param, slug):
 
 
 @entry_point.command()
-@click.argument("slug", callback=validate_slug)
+@click.argument("slug", callback=validate_slug, metavar="<user/repo>")
 @click.option(
     "-y",
     "--yes",

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -21,6 +21,9 @@ def ensure_top_level():
         raise exceptions.ShowyourworkException(
             "The `showyourwork` command must be called "
             "from the top level of a git repository."
+            "\n"
+            "`showyourwork` by itself runs a document build. "
+            "Did you mean to run `showyourwork setup`?"
         )
 
 


### PR DESCRIPTION
I forgot how to initialize a repo and couldn't figure it out from the error messages alone. These tweaks should help.

> "The best docs are good error messages"

Specifically, this:

1. Adds a suggestion if you call `showyourwork` outside of a git repo.
2. Makes the usage printout better. From:
```
> showyourwork setup
Usage: showyourwork setup [OPTIONS] SLUG
Try 'showyourwork setup --help' for help.

Error: Missing argument 'SLUG'.
```
this now prints:
```
Usage: showyourwork setup [OPTIONS] <user/repo>
Try 'showyourwork setup --help' for help.

Error: Missing argument '<user/repo>'.
```

I also added `build` to the gitignore for the showyourwork repo.