### PR TITLE
Add option to not commit overleaf changes

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -468,6 +468,27 @@ and make sure to check out :doc:`overleaf`.
             - src/tex/bib.bib
 
 
+.. _config.overleaf.gh_actions_sync:
+
+``overleaf.gh_actions_sync``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``bool``
+
+**Description:** Commit and push Overleaf changes to the GitHub remote when running on GitHub Actions?
+
+**Default:** ``true``
+
+**Required:** no
+
+**Example:**
+
+.. code-block:: yaml
+
+    overleaf:
+        gh_actions_sync: true
+
+
 .. _config.overleaf.id:
 
 ``overleaf.id``

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -164,8 +164,10 @@ def parse_overleaf():
     config["overleaf"]["id"] = config["overleaf"].get("id", None)
 
     # Set default for `gh_actions_sync`
-    config["overleaf"]["gh_actions_sync"] = config["overleaf"].get("gh_actions_sync", True)
-    
+    config["overleaf"]["gh_actions_sync"] = config["overleaf"].get(
+        "gh_actions_sync", True
+    )
+
     # Make sure `push` and `pull` are defined and they are lists
     config["overleaf"]["push"] = config["overleaf"].get("push", [])
     if config["overleaf"]["push"] is None:

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -163,6 +163,9 @@ def parse_overleaf():
     # Make sure `id` is defined
     config["overleaf"]["id"] = config["overleaf"].get("id", None)
 
+    # Set default for `gh_actions_sync`
+    config["overleaf"]["gh_actions_sync"] = config["overleaf"].get("gh_actions_sync", True)
+    
     # Make sure `push` and `pull` are defined and they are lists
     config["overleaf"]["push"] = config["overleaf"].get("push", [])
     if config["overleaf"]["push"] is None:

--- a/showyourwork/overleaf.py
+++ b/showyourwork/overleaf.py
@@ -434,6 +434,7 @@ def pull_files(
     error_if_local_changes=False,
     path=None,
     commit_changes=True,
+    push_changes=False
 ):
     """
     Pull files from the Overleaf remote.
@@ -451,6 +452,9 @@ def pull_files(
             (if running from a different directory).
         commit_changes (bool, optional): Commit changes to the article
             repository? Default ``True``.
+        push_changes (bool, optional): Push committed changes to the remote article
+            repository? Only applicable if ``commit_changes`` is ``True``. 
+            Default ``False``.
 
     """
     # Disable if user didn't specify an id or if there are no files
@@ -591,3 +595,10 @@ def pull_files(
             cwd=paths.user(path=path).repo,
             callback=callback,
         )
+        
+        if push_changes:
+            
+            get_stdout(
+                ["git", "push"],
+                cwd=paths.user(path=path).repo
+            )

--- a/showyourwork/overleaf.py
+++ b/showyourwork/overleaf.py
@@ -434,7 +434,7 @@ def pull_files(
     error_if_local_changes=False,
     path=None,
     commit_changes=True,
-    push_changes=False
+    push_changes=False,
 ):
     """
     Pull files from the Overleaf remote.
@@ -453,7 +453,7 @@ def pull_files(
         commit_changes (bool, optional): Commit changes to the article
             repository? Default ``True``.
         push_changes (bool, optional): Push committed changes to the remote article
-            repository? Only applicable if ``commit_changes`` is ``True``. 
+            repository? Only applicable if ``commit_changes`` is ``True``.
             Default ``False``.
 
     """
@@ -595,10 +595,7 @@ def pull_files(
             cwd=paths.user(path=path).repo,
             callback=callback,
         )
-        
+
         if push_changes:
-            
-            get_stdout(
-                ["git", "push"],
-                cwd=paths.user(path=path).repo
-            )
+
+            get_stdout(["git", "push"], cwd=paths.user(path=path).repo)

--- a/showyourwork/overleaf.py
+++ b/showyourwork/overleaf.py
@@ -433,7 +433,7 @@ def pull_files(
     error_if_missing=False,
     error_if_local_changes=False,
     path=None,
-    commit_changes=True
+    commit_changes=True,
 ):
     """
     Pull files from the Overleaf remote.
@@ -561,7 +561,7 @@ def pull_files(
             get_stdout(["diff", remote_file, file], callback=callback)
 
     if commit_changes:
-        
+
         def callback(code, stdout, stderr):
             if code == 0:
                 logger.info(

--- a/showyourwork/workflow/prep.smk
+++ b/showyourwork/workflow/prep.smk
@@ -61,5 +61,6 @@ onstart:
         overleaf.pull_files(
             config["overleaf"]["pull"],
             config["overleaf"]["id"],
-            commit_changes=not config["github_actions"]
+            commit_changes=not config["github_actions"],
+            push_changes=config["github_actions"] and config["overleaf"]["gh_actions_sync"]
         )

--- a/showyourwork/workflow/prep.smk
+++ b/showyourwork/workflow/prep.smk
@@ -60,5 +60,6 @@ onstart:
     if run_type == "preprocess" and get_repo_branch() == "main":
         overleaf.pull_files(
             config["overleaf"]["pull"],
-            config["overleaf"]["id"]
+            config["overleaf"]["id"],
+            commit_changes=not config["github_actions"]
         )


### PR DESCRIPTION
We don't need to commit the changes to the article repo after pulling from Overleaf on GitHub Actions, since we're not pushing back to the GitHub remote. This also helps with a bug @dfm found in the Actions caching step (see #187).