### PR TITLE
Auto remove `safe to test`

### DIFF
--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
         with:
           remove-labels: "safe to test"
-        
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -15,6 +15,12 @@ jobs:
     name: Run remote integration tests
     concurrency: showyourwork-remote
     steps:
+      - name: Remove `safe to test` label
+        if: ${{ (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test')) }}
+        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+        with:
+          remove-labels: "safe to test"
+        
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Automatically remove the `safe to test` label when the remote integration test runs on GH Actions. This allows us to re-run remote integration down the line without having to manually delete & re-add the label to a PR.