### PR TITLE
bugfix in log message

### DIFF
--- a/showyourwork/zenodo.py
+++ b/showyourwork/zenodo.py
@@ -453,7 +453,7 @@ class Zenodo:
         for entry in data:
 
             logger.debug(
-                f"Inspecting candidate file `{entry['filename']}` with hash `{file.name}`..."
+                f"Inspecting candidate file `{entry['filename']}` with hash `{rule_hashes.get(rule_name, None)}`..."
             )
 
             if (


### PR DESCRIPTION
Wrong hash displayed in the logs when attempting to restore a file from the Zenodo cache.