### PR TITLE
Remove aastex tweak

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -66,14 +66,11 @@
 
 % Generate the stamp on the first page
 \ifAddStamp
-  % Stamp position hacks (class-specific, as needed)
-  \@ifclassloaded{aastex631}{
-    \newcommand{\syw@stampXOffset}{-0.60}
-    \newcommand{\syw@stampYOffset}{0.00}
-  }{
-    \newcommand{\syw@stampXOffset}{0.00}
-    \newcommand{\syw@stampYOffset}{0.00}
-  }
+  % No-op offsets. Override these for, e.g.,
+  % specific documentclasses that require a
+  % different default stamp position.
+  \newcommand{\syw@stampXOffset}{0.00}
+  \newcommand{\syw@stampYOffset}{0.00}
 
   % Define the stamp
   \newcommand{\syw@stamp}{%


### PR DESCRIPTION
Removes the hack we added to compensate for the weird geometry of the aastex631 documentclass. It's still true that the right margin is offset by about 0.6in relative to where TikZ believes it is, but the stamp looks good in its default position. Also, if the user chooses the `modern` option when loading the class, this hack caused the stamp to be placed too close to the edge of the paper. Let's just keep things simple and remove the hack.