### PR TITLE
Margin links for variables

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -179,7 +179,16 @@
   }%
 }
 
-% Hack `showkeys' to show margin links for figures
+% Variable script icon: links to a line in the Snakefile
+\newcommand\syw@Variable[1]{%
+  \raisebox{0pt}[6pt][0pt]{%
+    \href{\syw@url/blob/\syw@sha/\usevalue{#1}}{%
+      \color{sywBlue}\faGithub%
+    }%
+  }%
+}
+
+% Hack `showkeys' to show margin links for figures and variables
 % See https://tex.stackexchange.com/a/580553
 \renewcommand\showkeyslabelformat[1]{%
   \normalfont%
@@ -191,6 +200,9 @@
     \IfEq*{\usevalue{#1_datasetOne}}{KEYNOTFOUND}{}{\syw@DatasetOne{#1_datasetOne}}
     \IfEq*{\usevalue{#1_script}}{KEYNOTFOUND}{}{\syw@Script{#1_script}}
   }
+  % Link to the line in the Snakefile that generates a given variable
+  % in the texfile
+  \IfEq*{\usevalue{#1_rule}}{KEYNOTFOUND}{}{\syw@Variable{#1_rule}}
 }
 
 % Set the graphics path for all figures
@@ -198,5 +210,5 @@
 
 % Alias of \input for syw-controlled files
 \newcommand\variable[1]{%
-  \input{#1}\unskip%
+  \input{#1}\label{#1}\unskip%
 }

--- a/showyourwork/workflow/rules/dag.smk
+++ b/showyourwork/workflow/rules/dag.smk
@@ -134,13 +134,17 @@ def infer_variable_provenance(dag):
 
     # Gather \variable provenance info so we can access it on the TeX side
     config["variables"] = {}
+
+    # Loop over all files defined in \variable commands
     for file in config["tree"]["files"]:
         file = Path(file).resolve()
-
-        # Assemble input-output information
         for job in dag.jobs:
+            # Find the job (and rule) that generates `file`
             if file in [Path(str(file)).resolve() for file in job.output]:
+                # Get the path to the Snakefile that defines that rule
                 rulepath = str(Path(job.rule.snakefile).relative_to(paths.user().repo))
+                # Try to find the line number; if we can't, simply link to the
+                # Snakefile, without line number highlighting
                 with open(job.rule.snakefile, "r") as f:
                     for n, line in enumerate(f.readlines()):
                         if re.match(rf"\s*rule\s*{job.rule.name}:", line):

--- a/showyourwork/workflow/rules/dag.smk
+++ b/showyourwork/workflow/rules/dag.smk
@@ -11,6 +11,8 @@ from showyourwork.config import get_upstream_dependencies
 from showyourwork.patches import get_snakemake_variable, patch_snakemake_cache_optimization
 from showyourwork.zenodo import get_dataset_urls
 import snakemake
+import os
+import re
 from collections import defaultdict
 
 
@@ -121,6 +123,34 @@ def add_dag_metadata_to_config(dag):
     config["dag_dependencies_recursive"] = recursive_dependencies
 
 
+def infer_variable_provenance(dag):
+    """
+    Try to infer the Snakefiles and line numbers where the rules generating
+    files specified in the `\variable` command are defined.
+
+    """
+    # Snakemake config
+    config = snakemake.workflow.config
+
+    # Gather \variable provenance info so we can access it on the TeX side
+    config["variables"] = {}
+    for file in config["tree"]["files"]:
+        file = Path(file).resolve()
+
+        # Assemble input-output information
+        for job in dag.jobs:
+            if file in [Path(str(file)).resolve() for file in job.output]:
+                rulepath = str(Path(job.rule.snakefile).relative_to(paths.user().repo))
+                with open(job.rule.snakefile, "r") as f:
+                    for n, line in enumerate(f.readlines()):
+                        if re.match(rf"\s*rule\s*{job.rule.name}:", line):
+                            rulepath += rf"\#L{n+1}"
+                            break
+                pre = Path(os.path.commonprefix([file, paths.user().tex]))
+                filename = str(file.relative_to(pre))
+                config["variables"][f"{filename}_rule"] = rulepath
+
+
 def WORKFLOW_GRAPH(*args):
     """
     This is a dummy input function for the main rules of the build (``syw__pdf``
@@ -153,6 +183,9 @@ def WORKFLOW_GRAPH(*args):
         # Infer figure deps from the DAG
         logger.debug("Inferring figure dependencies recursively...")
         infer_additional_figure_dependencies()
+
+        # Infer variable deps from the DAG
+        infer_variable_provenance(dag)
 
         # Optimize the DAG by removing jobs upstream of cache hits
         if config["optimize_caching"]:

--- a/showyourwork/workflow/scripts/pdf.py
+++ b/showyourwork/workflow/scripts/pdf.py
@@ -43,6 +43,10 @@ if __name__ == "__main__":
     \addvalue{((- key -))}{((- value -))}
     ((* endfor *))
 
+    ((* for key, value in variables.items() *))
+    \addvalue{((- key -))}{((- value -))}
+    ((* endfor *))
+
     % Check if the Git tag is set (i.e. is it an empty string)
     ((* if sha_tag_header != "" *))
     \newcommand{\gitHeader}{((- sha_tag_header -))}

--- a/tests/integration/test_variable.py
+++ b/tests/integration/test_variable.py
@@ -1,3 +1,4 @@
+import pytest
 from helpers import TemporaryShowyourworkRepository
 
 from showyourwork.config import edit_yaml
@@ -15,6 +16,8 @@ age = np.random.normal(14.0, 1.0)
 with open(paths.output / "age_of_universe.txt", "w") as f:
     f.write(f"{age:.3f}")
 """
+
+pytestmark = pytest.mark.remote
 
 
 class TestLatexVariable(TemporaryShowyourworkRepository):

--- a/tests/integration/test_variable.py
+++ b/tests/integration/test_variable.py
@@ -20,9 +20,6 @@ with open(paths.output / "age_of_universe.txt", "w") as f:
 class TestLatexVariable(TemporaryShowyourworkRepository):
     """Test a workflow with dynamic quantities imported into the tex file."""
 
-    # No need to test this on CI
-    local_build_only = True
-
     def customize(self):
         """Create and edit all the necessary files for the workflow."""
         # Create the script


### PR DESCRIPTION
Adds margin links wherever a `\variable` command is found in the manuscript. The links point to the line in the Snakefile (or other Snakemake file) where the rule that generates the programmatic output is defined (if the workflow can figure it out!)