### PR TITLE
Fork snakemake

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -573,33 +573,6 @@ repository. Exact names are required; no glob syntax allowed.
             - src/tex/figures
 
 
-.. _config.require_inputs:
-
-``require_inputs``
-^^^^^^^^^^^^^^^^^^
-
-**Type:** ``bool``
-
-**Description:** If there is no valid rule to generate a given output file
-(because of, e.g., a missing input file), but the output file itself is present on disk,
-Snakemake will not by default raise an error. This can be useful for running
-workflows locally, but it can compromise the reproducibility of a workflow when
-a third party attempts to run it. Therefore, the default behavior in |showyourwork|
-is to require all output files to be programmatically generatable when running
-the workflow, *even if* the output files exist on disk already. Otherwise, an
-error is thrown. Set this option to ``false`` to override this behavior.
-
-**Required:** no
-
-**Default:** ``true``
-
-**Example:**
-
-.. code-block:: yaml
-
-    require_inputs: true
-
-
 .. _config.run_cache_rules_on_ci:
 
 ``run_cache_rules_on_ci``

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -121,10 +121,9 @@ incomplete. When this happens, ``showyourwork`` tells the user:
 .. code-block:: text
 
   If you are sure that certain files are not incomplete, mark them as complete with
+  the --cleanup-metadata <filenames> flag.
 
-    showyourwork build --cleanup-metadata <filenames>
-
-  To re-generate the files rerun showyourwork build with the --rerun-incomplete flag.
+  To re-generate the files rerun your command with the --rerun-incomplete flag.
 
 Sometimes, however, the ``--cleanup-metadata`` argument does not successfully
 clean up the incomplete files. This may be due to either an issue with Snakemake

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -461,3 +461,23 @@ local installation of showyourwork*.)
 
 So, if you run into this error, we recommend you download all required files directly from
 the journal and include them (making sure to ``git add`` them) in your `src/tex` folder.
+
+
+Branch rename failed
+--------------------
+
+In versions of ``showyourwork`` prior to ``0.3.2``, users may occasionally run into the
+following error when attempting to run a third party's workflow:
+
+.. code-block:: text
+
+  Fetching Overleaf repo...
+  error: refname refs/heads/master not found
+  fatal: Branch rename failed
+
+This is a bug in ``showyourwork`` related to the fact that the default git branch on Overleaf
+projects is called ``master``, while the default branch on GitHub is called ``main``. This
+isn't an issue unless users don't have the correct credentials to access an Overleaf repository,
+in which case the ``git clone`` silently fails and no ``master`` branch is created.
+If you run into this error, simply delete or comment out the ``overleaf:`` section of the ``environment.yml``
+workflow config and re-run the workflow.

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -389,14 +389,26 @@ build your article. You can read more about environment files
 By default, only the bare minimum specs are included
 (e.g., ``numpy`` and ``matplotlib``). Feel free to manually add to this list
 (noting that packages that can only be installed via ``pip`` should be placed in
-the ``pip`` section). It's recommended to either pin a specific version
-(i.e., ``matplotlib==3.3.4``) or specify a minimum version
-(i.e., ``matplotlib>=3.0.0``) for your packages. Just be aware that overconstrained
-requirements may break on other platforms
+the ``pip`` section). For packages listed under ``dependencies``, it is highly
+recommended that users specify **explict channels** and pin **exact versions**, e.g.:
+
+.. code-block:: text
+
+  dependencies:
+    - conda-forge::python=3.9
+
+For ``pip`` dependencies, users should also pin exact versions, e.g.:
+
+.. code-block:: text
+
+  - pip:
+    - matplotlib==3.3.4
+
+Note that overconstrained requirements may break the installation on other platforms
 (see `this post <https://stackoverflow.com/questions/39280638/how-to-share-conda-environments-across-platforms>`_),
-so you should probably only pin the direct dependencies of your project.
-If you alread have a ``conda`` environment for your project, you can export
-these direct dependencies -- the ones that you explicitly installed in the enviornment --
+so users should consider only pinning the *direct* dependencies of their project.
+If a ``conda`` environment already exists for a project, one can export
+these direct dependencies -- the ones whose installation was explicitly requested in the enviornment --
 by running
 
 .. code-block:: bash
@@ -404,8 +416,7 @@ by running
     conda env export --from-history | grep -v "^prefix: " > environment.yml
 
 The ``grep`` command removes the line in the environment file with the absolute path
-to your ``conda`` environment, which probably won't be useful to anyone else running
-your code!
+to the ``conda`` environment.
 
 
 .. _license:

--- a/showyourwork/cli/__init__.py
+++ b/showyourwork/cli/__init__.py
@@ -10,4 +10,33 @@ setting. This allows users running any version of ``showyourwork`` to build any
 article.
 
 """
-from .main import entry_point
+import sys
+
+from .main import DEFAULT_SUBCOMMAND, OPTIONS, SUBCOMMANDS, main
+
+
+def entry_point():
+    """
+    Modify the call from `showyourwork ...` to `showyourwork build...`
+    if the user didn't explicitly provide a valid subcommand or option.
+
+    Click can in principle handle this (the `@click.group` decorator accepts
+    an `invoke_without_command` option) but if we do that I don't _think_
+    we can simultaneously set `ignore_unknown_options`. We need to be able
+    to forward unknown options directly to `snakemake`.
+
+    This hack allows users to call, e.g.,
+
+        showyourwork --rerun-incomplete
+
+    instead of
+
+        showyourwork build --rerun-incomplete
+
+    (the invocation they had to use previously). We allow this by injecting
+    the `build` subcommand into `sys.argv` prior to click taking control.
+
+    """
+    if len(sys.argv) == 1 or not (sys.argv[1] in SUBCOMMANDS + OPTIONS):
+        sys.argv.insert(1, DEFAULT_SUBCOMMAND)
+    main()

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -120,7 +120,7 @@ def run_in_env(command, **kwargs):
             "Creating a new conda environment in ~/.showyourwork/env..."
         )
         get_stdout(
-            f"CONDARC={paths.showyourwork().envs / '.condarc'} conda create -p {paths.user().env} --file {workflow_envfile} -q",
+            f"CONDARC={paths.showyourwork().envs / '.condarc'} conda create -p {paths.user().env} -f {workflow_envfile} -q",
             shell=True,
         )
         shutil.copy(workflow_envfile, cached_envfile)
@@ -137,7 +137,7 @@ def run_in_env(command, **kwargs):
         if not cache_hit:
             logger.info("Updating conda environment in ~/.showyourwork/env...")
             get_stdout(
-                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda update -p {paths.user().env} --file {workflow_envfile} --prune -q",
+                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda update -p {paths.user().env} -f {workflow_envfile} --prune -q",
                 shell=True,
             )
             shutil.copy(workflow_envfile, cached_envfile)

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -120,7 +120,7 @@ def run_in_env(command, **kwargs):
             "Creating a new conda environment in ~/.showyourwork/env..."
         )
         get_stdout(
-            f"conda create --strict-channel-priority -p {paths.user().env} --file {workflow_envfile} -q",
+            f"CONDARC={paths.showyourwork().envs / '.condarc'} conda create -p {paths.user().env} --file {workflow_envfile} -q",
             shell=True,
         )
         shutil.copy(workflow_envfile, cached_envfile)
@@ -137,7 +137,7 @@ def run_in_env(command, **kwargs):
         if not cache_hit:
             logger.info("Updating conda environment in ~/.showyourwork/env...")
             get_stdout(
-                f"conda update --strict-channel-priority -p {paths.user().env} --file {workflow_envfile} --prune -q",
+                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda update -p {paths.user().env} --file {workflow_envfile} --prune -q",
                 shell=True,
             )
             shutil.copy(workflow_envfile, cached_envfile)

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -120,7 +120,7 @@ def run_in_env(command, **kwargs):
             "Creating a new conda environment in ~/.showyourwork/env..."
         )
         get_stdout(
-            f"CONDARC={paths.showyourwork().envs / '.condarc'} conda create -p {paths.user().env} -f {workflow_envfile} -q",
+            f"conda env create --strict-channel-priority -p {paths.user().env} -f {workflow_envfile} -q",
             shell=True,
         )
         shutil.copy(workflow_envfile, cached_envfile)
@@ -137,7 +137,7 @@ def run_in_env(command, **kwargs):
         if not cache_hit:
             logger.info("Updating conda environment in ~/.showyourwork/env...")
             get_stdout(
-                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda update -p {paths.user().env} -f {workflow_envfile} --prune -q",
+                f"conda env update --strict-channel-priority -p {paths.user().env} -f {workflow_envfile} --prune -q",
                 shell=True,
             )
             shutil.copy(workflow_envfile, cached_envfile)

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 # Require this version of conda or greater
-MIN_CONDA_VERSION = Version("4.14.0")
+MIN_CONDA_VERSION = Version("4.12.0")
 
 
 def run_in_env(command, **kwargs):

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -74,7 +74,9 @@ def run_in_env(command, **kwargs):
     # Get conda version
     conda_version = get_stdout("conda -V", shell=True)
     try:
-        conda_version = Version(re.match("^conda (.*?)$", foo).groups()[0])
+        conda_version = Version(
+            re.match("^conda (.*?)$", conda_version).groups()[0]
+        )
     except:
         raise exceptions.CondaVersionError(MIN_CONDA_VERSION)
     if conda_version < MIN_CONDA_VERSION:

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -120,7 +120,7 @@ def run_in_env(command, **kwargs):
             "Creating a new conda environment in ~/.showyourwork/env..."
         )
         get_stdout(
-            f"conda env create --strict-channel-priority -p {paths.user().env} -f {workflow_envfile} -q",
+            f"CONDARC={paths.showyourwork().envs / '.condarc'} conda env create -p {paths.user().env} -f {workflow_envfile} -q",
             shell=True,
         )
         shutil.copy(workflow_envfile, cached_envfile)
@@ -137,7 +137,7 @@ def run_in_env(command, **kwargs):
         if not cache_hit:
             logger.info("Updating conda environment in ~/.showyourwork/env...")
             get_stdout(
-                f"conda env update --strict-channel-priority -p {paths.user().env} -f {workflow_envfile} --prune -q",
+                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda env update -p {paths.user().env} -f {workflow_envfile} --prune -q",
                 shell=True,
             )
             shutil.copy(workflow_envfile, cached_envfile)

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -8,6 +8,12 @@ import click
 from .. import __version__, exceptions, git
 from . import commands
 
+# Store command & option metadata here so we can make `build`
+# the default subcommand in __init__.py
+DEFAULT_SUBCOMMAND = "build"
+SUBCOMMANDS = ["build", "cache", "clean", "setup", "tarball"]
+OPTIONS = ["-v", "--version", "--help"]
+
 
 def ensure_top_level():
     """Ensures we're running commands in the top level of a git repo.
@@ -67,7 +73,7 @@ def echo(text="", **kwargs):
         click.echo(text, **kwargs)
 
 
-@click.group(invoke_without_command=True)
+@click.group
 @click.option(
     "-v",
     "--version",
@@ -75,7 +81,7 @@ def echo(text="", **kwargs):
     help="Show the program version and exit.",
 )
 @click.pass_context
-def entry_point(context, version):
+def main(context, version):
     """Easily build open-source, reproducible scientific articles."""
     # Parse
     if version:
@@ -85,7 +91,7 @@ def entry_point(context, version):
         context.invoke(build)
 
 
-@entry_point.command(
+@main.command(
     context_settings=dict(
         ignore_unknown_options=True,
     )
@@ -194,7 +200,7 @@ def validate_slug(context, param, slug):
         raise click.BadParameter("Must have the form `user/repo`.")
 
 
-@entry_point.command()
+@main.command()
 @click.argument("slug", callback=validate_slug, metavar="<user/repo>")
 @click.option(
     "-y",
@@ -259,7 +265,7 @@ def setup(slug, yes, quiet, cache, overleaf, ssh, version, action_spec):
     commands.setup(slug, cache, overleaf, ssh, version, action_spec)
 
 
-@entry_point.command()
+@main.command()
 @click.option(
     "-f",
     "--force",
@@ -278,7 +284,7 @@ def clean(force, deep):
     commands.clean(force, deep)
 
 
-@entry_point.command()
+@main.command()
 def tarball():
     """Generate a tarball of the build in the current working directory."""
     ensure_top_level()
@@ -286,7 +292,7 @@ def tarball():
     commands.tarball()
 
 
-@entry_point.group()
+@main.group()
 @click.pass_context
 def cache(ctx):
     """Caching-related operations."""

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -337,9 +337,6 @@ def parse_config():
             "show_git_sha_or_tag", False
         )
 
-        #: Require inputs to all rules to be present on disk for build to pass?
-        config["require_inputs"] = config.get("require_inputs", True)
-
         #: Allow cached rules to run on CI if there's a cache miss?
         config["run_cache_rules_on_ci"] = config.get(
             "run_cache_rules_on_ci", False

--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
@@ -1,6 +1,6 @@
 dependencies:
-  - numpy=1.19.2
-  - pip=21.0.1
-  - python=3.9
+  - anaconda::numpy=1.19.2
+  - anaconda::pip=21.0.1
+  - anaconda::python=3.9
   - pip:
       - matplotlib==3.4.3

--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
@@ -1,6 +1,6 @@
 dependencies:
-  - anaconda::numpy=1.19.2
-  - anaconda::pip=21.0.1
-  - anaconda::python=3.9
+  - conda-forge::numpy=1.19.2
+  - conda-forge::pip=21.0.1
+  - conda-forge::python=3.9
   - pip:
       - matplotlib==3.4.3

--- a/showyourwork/exceptions/other.py
+++ b/showyourwork/exceptions/other.py
@@ -17,6 +17,14 @@ class CondaNotFoundError(ShowyourworkException):
         )
 
 
+class CondaVersionError(ShowyourworkException):
+    def __init__(self, min_version, version="[unknown]"):
+        super().__init__(
+            f"Showyourwork requires conda version {min_version} or greater, "
+            f"but version {version} is installed. Please upgrade conda."
+        )
+
+
 class ShowyourworkNotFoundError(ShowyourworkException):
     def __init__(self, path):
         super().__init__(

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -375,7 +375,10 @@ def patch_snakemake_wait_for_files():
     """
 
     def wait_for_files(
-        files, latency_wait=3, force_stay_on_remote=False, ignore_pipe=False
+        files,
+        latency_wait=3,
+        force_stay_on_remote=False,
+        ignore_pipe_or_service=False,
     ):
         """Wait for given files to be present in the filesystem."""
         files = list(files)
@@ -392,7 +395,13 @@ def patch_snakemake_wait_for_files():
                         and (force_stay_on_remote or f.should_stay_on_remote)
                     )
                     else os.path.exists(f)
-                    if not (snakemake.io.is_flagged(f, "pipe") and ignore_pipe)
+                    if not (
+                        (
+                            snakemake.io.is_flagged(f, "pipe")
+                            or snakemake.io.is_flagged(f, "service")
+                        )
+                        and ignore_pipe_or_service
+                    )
                     else True
                 )
             ]

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -379,9 +379,14 @@ def patch_snakemake_wait_for_files():
         latency_wait=3,
         force_stay_on_remote=False,
         ignore_pipe_or_service=False,
+        **kwargs,
     ):
         """Wait for given files to be present in the filesystem."""
         files = list(files)
+
+        # Compat for older versions of Snakemake
+        if ignore_pipe := kwargs.get("ignore_pipe") is not None:
+            ignore_pipe_or_service = ignore_pipe
 
         def get_missing():
             return [

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -19,29 +19,6 @@ except ModuleNotFoundError:
     snakemake = None
 
 
-class SnakemakeFormatter(logging.Formatter):
-    """
-    Format Snakemake errors before displaying them on stdout.
-
-    Sometimes, Snakemake fails with suggestions for commands to fix certain
-    issues. We intercept those suggestions here, replacing them with the
-    corresponding showyourwork syntax for convenience.
-    """
-
-    replacements = {
-        "snakemake --cleanup-metadata": "showyourwork build --cleanup-metadata",
-        "rerun your command with the --rerun-incomplete flag": "rerun showyourwork build with the --rerun-incomplete flag",
-        "It can be removed with the --unlock argument": "It can be removed by passing --unlock to showyourwork build",
-    }
-
-    def format(self, record):
-        message = record.getMessage()
-        for key, value in self.replacements.items():
-            message = message.replace(key, value)
-        record.message = message
-        return message
-
-
 def patch_snakemake_cache(zenodo_doi, sandbox_doi):
     """
     Patches the Snakemake cache functionality to
@@ -255,9 +232,6 @@ def patch_snakemake_logging():
     if not hasattr(snakemake_logger, "custom_stream_handler"):
         snakemake_logger.custom_stream_handler = ColorizingStreamHandler()
         snakemake_logger.custom_stream_handler.setLevel(logging.ERROR)
-        snakemake_logger.custom_stream_handler.setFormatter(
-            SnakemakeFormatter()
-        )
         snakemake_logger.logger.addHandler(
             snakemake_logger.custom_stream_handler
         )

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -6,7 +6,6 @@ so if we change the Snakemake version (currently pinned at 16.5.5), we may have
 to update the code in this file.
 
 """
-import inspect
 import logging
 import types
 
@@ -41,23 +40,6 @@ class SnakemakeFormatter(logging.Formatter):
             message = message.replace(key, value)
         record.message = message
         return message
-
-
-def get_snakemake_variable(name, default=None):
-    """
-    Infer the value of a variable within Snakemake.
-
-    This is extremely hacky, as it inspects local variables across
-    various frames in the call stack. This function should be used for
-    debugging/development, but not in production.
-
-    """
-    levels = inspect.stack()
-    for level in levels:
-        value = level.frame.f_locals.get(name, None)
-        if value is not None:
-            return value
-    return default
 
 
 def patch_snakemake_cache(zenodo_doi, sandbox_doi):

--- a/showyourwork/userrules.py
+++ b/showyourwork/userrules.py
@@ -52,16 +52,8 @@ def process_user_rules():
         if not ur.message:
             ur.message = f"Running user rule {ur.name}..."
 
-        # Add script as an explicit input
-        if ur.script:
-            script = ur.script
-            script = script.replace("{wildcards.", "{")
-            ur.set_input(script)
-        elif ur.notebook:
-            notebook = ur.notebook
-            notebook = notebook.replace("{wildcards.", "{")
-            ur.set_input(notebook)
-        elif ur.is_run:
+        # Disallow `run` directives: enforce scripts!
+        if ur.is_run:
             raise exceptions.RunDirectiveNotAllowedInUserRules(ur.name)
 
         # Record any cached output

--- a/showyourwork/workflow/build.smk
+++ b/showyourwork/workflow/build.smk
@@ -3,7 +3,7 @@ The Snakefile for the main article build step.
 
 """
 from showyourwork import paths, exceptions, overleaf
-from showyourwork.patches import patch_snakemake_wait_for_files, patch_snakemake_logging, patch_snakemake_missing_input_leniency
+from showyourwork.patches import patch_snakemake_logging
 from showyourwork.config import parse_config, get_run_type
 from showyourwork.logging import get_logger
 from showyourwork.userrules import process_user_rules
@@ -72,17 +72,6 @@ if (paths.user().temp / "config.json").exists():
     # Include custom rules defined by the user
     include: (paths.user().repo / "Snakefile").as_posix()
     process_user_rules()
-
-
-    # Hack to display a custom message when a figure output is missing
-    patch_snakemake_wait_for_files()
-
-
-    # Snakemake workflows complete successfully if there's no rule to generate
-    # a given file but it is present on disk. This is bad for third-party
-    # reproducibility, so here we hack it to require all inputs to be present.
-    if config["require_inputs"]:
-        patch_snakemake_missing_input_leniency()
 
 
 else:

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -1,5 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - defaults
-channel_priority: strict

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -1,5 +1,5 @@
 channels:
-  - defaults
   - conda-forge
   - bioconda
+  - defaults
 channel_priority: strict

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -1,0 +1,5 @@
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+channel_priority: true

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -1,5 +1,4 @@
 channels:
   - defaults
   - conda-forge
-  - bioconda
 channel_priority: true

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -2,4 +2,4 @@ channels:
   - defaults
   - conda-forge
   - bioconda
-channel_priority: false
+channel_priority: strict

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -1,11 +1,10 @@
 dependencies:
-  - anaconda::python=3.9
-  - anaconda::pip=21.0.1
+  - conda-forge::python=3.9
+  - conda-forge::pip=21.0.1
   - conda-forge::tectonic=0.8.0
   - conda-forge::mamba=0.25.0
   - bioconda::snakemake-minimal=7.14.0
-  - conda-forge::imagemagick
-  - anaconda::graphviz
+  - conda-forge::imagemagick=7.1.0.27
   - pip:
       - click==8.0.4
       - pyyaml==6.0

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -2,8 +2,8 @@ dependencies:
   - python=3.9
   - pip=21.0.1
   - conda-forge::tectonic=0.8.0
-  - conda-forge::mamba=0.23.3
-  - bioconda::snakemake-minimal=6.15.5
+  - conda-forge::mamba=0.25.0
+  - bioconda::snakemake-minimal=7.14.0
   - conda-forge::imagemagick
   - graphviz
   - pip:

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -3,11 +3,12 @@ dependencies:
   - conda-forge::pip=21.0.1
   - conda-forge::tectonic=0.8.0
   - conda-forge::mamba=0.25.0
-  - bioconda::snakemake-minimal=7.14.0
   - conda-forge::imagemagick=7.1.0.27
+  - conda-forge::datrie=0.8.2
   - pip:
       - click==8.0.4
       - pyyaml==6.0
       - requests==2.25.1
       - jinja2==3.0.3
       - graphviz==0.19.1
+      - git+https://github.com/showyourwork/snakemake.git@main#egg=snakemake

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -1,11 +1,11 @@
 dependencies:
-  - python=3.9
-  - pip=21.0.1
+  - anaconda::python=3.9
+  - anaconda::pip=21.0.1
   - conda-forge::tectonic=0.8.0
   - conda-forge::mamba=0.25.0
   - bioconda::snakemake-minimal=7.14.0
   - conda-forge::imagemagick
-  - graphviz
+  - anaconda::graphviz
   - pip:
       - click==8.0.4
       - pyyaml==6.0

--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -52,7 +52,7 @@
 
 % Showyourwork logo
 \newcommand{\showyourwork}{%
-  \smash{\raisebox{-1.7ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
+  \smash{\raisebox{-1.4ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
 }
 
 % Define custom colors

--- a/showyourwork/workflow/rules/dag.smk
+++ b/showyourwork/workflow/rules/dag.smk
@@ -170,7 +170,12 @@ def WORKFLOW_GRAPH(*args):
     snakemake.workflow.checkpoints.syw__dag.get()
 
     # Get the workflow graph
-    dag = snakemake.workflow.dag
+    dag = None
+    if hasattr(snakemake.workflow, "dag"):
+        dag = snakemake.workflow.dag
+    elif hasattr(snakemake.workflow, "workflow"):
+        if hasattr(snakemake.workflow.workflow, "dag"):
+            dag = snakemake.workflow.dag
 
     if dag is None:
 

--- a/showyourwork/workflow/rules/dag.smk
+++ b/showyourwork/workflow/rules/dag.smk
@@ -175,7 +175,7 @@ def WORKFLOW_GRAPH(*args):
         dag = snakemake.workflow.dag
     elif hasattr(snakemake.workflow, "workflow"):
         if hasattr(snakemake.workflow.workflow, "dag"):
-            dag = snakemake.workflow.dag
+            dag = snakemake.workflow.workflow.dag
 
     if dag is None:
 

--- a/showyourwork/workflow/rules/dag.smk
+++ b/showyourwork/workflow/rules/dag.smk
@@ -8,7 +8,7 @@ itself.
 """
 from showyourwork import paths, logging
 from showyourwork.config import get_upstream_dependencies
-from showyourwork.patches import get_snakemake_variable, patch_snakemake_cache_optimization
+from showyourwork.patches import patch_snakemake_cache_optimization
 from showyourwork.zenodo import get_dataset_urls
 import snakemake
 import os
@@ -170,7 +170,7 @@ def WORKFLOW_GRAPH(*args):
     snakemake.workflow.checkpoints.syw__dag.get()
 
     # Get the workflow graph
-    dag = get_snakemake_variable("dag", None)
+    dag = snakemake.workflow.dag
 
     if dag is None:
 

--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -433,17 +433,26 @@ def get_json_tree():
     ]
 
     # Separate into dynamic and static figures
-    free_floating_static = [
-        graphic
-        for graphic in free_floating_graphics
-        if (paths.user().repo / graphic).parents[0] == paths.user().figures
-        and (paths.user().static / Path(graphic).name).exists()
-    ]
-    free_floating_dynamic = [
-        graphic
-        for graphic in free_floating_graphics
-        if graphic not in free_floating_static
-    ]
+    free_floating_static = list(
+        set(
+            [
+                graphic
+                for graphic in free_floating_graphics
+                if (paths.user().repo / graphic).parents[0]
+                == paths.user().figures
+                and (paths.user().static / Path(graphic).name).exists()
+            ]
+        )
+    )
+    free_floating_dynamic = list(
+        set(
+            [
+                graphic
+                for graphic in free_floating_graphics
+                if graphic not in free_floating_static
+            ]
+        )
+    )
 
     # Add entries to the tree: dynamic figures
     # (User should provide a custom Snakemake rule)

--- a/tests/integration/test_missing_inputs.py
+++ b/tests/integration/test_missing_inputs.py
@@ -25,7 +25,7 @@ class TestMissingScript(
         try:
             super().build_local()
         except Exception as e:
-            if not "src/tex/figures/test_figure.pdf" in str(e):
+            if not "ms.pdf" in str(e):
                 raise Exception(f"Incorrect exception message: {str(e)}")
         else:
             raise Exception(
@@ -60,7 +60,7 @@ class TestDeletedScript(
         try:
             super().build_local()
         except Exception as e:
-            if not "src/scripts/test_figure.py" in str(e):
+            if not "src/tex/figures/test_figure.pdf" in str(e):
                 raise Exception(f"Incorrect exception message: {str(e)}")
         else:
             raise Exception(

--- a/tests/integration/test_missing_inputs.py
+++ b/tests/integration/test_missing_inputs.py
@@ -25,7 +25,7 @@ class TestMissingScript(
         try:
             super().build_local()
         except Exception as e:
-            if not "src/scripts/test_figure.py" in str(e):
+            if not "src/tex/figures/test_figure.pdf" in str(e):
                 raise Exception(f"Incorrect exception message: {str(e)}")
         else:
             raise Exception(


### PR DESCRIPTION
I'm not sure if this is going to work yet, but I want to try to fork Snakemake instead of applying all the current monkey patches during runtime on the showyourwork side. This is, of course, the better approach, but the issue is that whatever we do we need to make backwards-compatible with versions of showyourwork <= 0.3.1, which apply monkeypatches assuming the version of Snakemake that is installed is 6.15.5 (making it very, very difficult to upgrade Snakemake -- see #200). This was a poor design decision early on, but I'm afraid we're stuck with the consequences.

More on this soon.