### PR TITLE
Allow users to disable cache

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,6 +14,27 @@ customize several aspects of the workflow. Below is a list of all
 available options.
 
 
+.. _config.cache:
+
+``cache``
+^^^^^^^^^
+
+**Type:** ``bool``
+
+**Description:** Flag controlling whether or not caching on Zenodo/Zenodo Sandbox
+should be performed. Set this to ``false`` to disable caching.
+
+**Required:** no
+
+**Default:** ``true``
+
+**Example:**
+
+.. code-block:: yaml
+
+    cache: true
+
+
 .. _config.dag:
 
 ``dag``

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,10 +14,10 @@ customize several aspects of the workflow. Below is a list of all
 available options.
 
 
-.. _config.cache:
+.. _config.cache_on_zenodo:
 
-``cache``
-^^^^^^^^^
+``cache_on_zenodo``
+^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``bool``
 
@@ -32,7 +32,7 @@ should be performed. Set this to ``false`` to disable caching.
 
 .. code-block:: yaml
 
-    cache: true
+    cache_on_zenodo: true
 
 
 .. _config.dag:

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -63,7 +63,7 @@ def render_config(cwd="."):
     config = yaml.safe_load(config)
 
     # Merge with the zenodo config file, if present
-    if config.pop("cache", True):
+    if config.get("cache_on_zenodo", True):
         file = Path(cwd) / "zenodo.yml"
         if file.exists():
             with open(file, "r") as f:

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -63,10 +63,11 @@ def render_config(cwd="."):
     config = yaml.safe_load(config)
 
     # Merge with the zenodo config file, if present
-    file = Path(cwd) / "zenodo.yml"
-    if file.exists():
-        with open(file, "r") as f:
-            config.update(yaml.safe_load(f.read()))
+    if config.pop("cache", True):
+        file = Path(cwd) / "zenodo.yml"
+        if file.exists():
+            with open(file, "r") as f:
+                config.update(yaml.safe_load(f.read()))
 
     # Save to a temporary YAML file
     with open(paths.user().temp / "showyourwork.yml", "w") as f:


### PR DESCRIPTION
This PR allows users to set `cache: false` in the `showyourwork.yml` config file to disable the Zenodo/Zenodo Sandbox caching functionality. Useful when, e.g., Zenodo Sandbox is down (as is the case right now -- I'm experiencing super high latency, which reaaaaally slows down the build).