### PR TITLE
Matrix strategy for workflow versions

### DIFF
--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -11,6 +11,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     name: Run local integration tests
+    strategy:
+      matrix:
+        workflow-version:
+          - ${{ github.sha }}
+          - 0.3.1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,4 +37,4 @@ jobs:
 
       - name: Run local integration tests
         shell: bash -l {0}
-        run: python -m pytest tests/integration
+        run: python -m pytest tests/integration --workflow-version ${{ matrix.workflow-version }}

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run local integration tests
     strategy:
+      fail-fast: false
       matrix:
         workflow-version:
           - ${{ github.sha }}

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -15,6 +15,7 @@ jobs:
     name: Run remote integration tests
     concurrency: showyourwork-remote
     strategy:
+      fail-fast: false
       matrix:
         workflow-version:
           - ${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Run remote integration tests
     concurrency: showyourwork-remote
+    strategy:
+      matrix:
+        workflow-version:
+          - ${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}
+          - 0.3.1
     steps:
       - name: Remove `safe to test` label
         if: ${{ (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test')) }}
@@ -41,12 +46,10 @@ jobs:
 
       - name: Run remote integration tests
         shell: bash -l {0}
-        run: python -m pytest --remote -m "remote" tests/integration
+        run: python -m pytest --remote -m "remote" tests/integration --workflow-version ${{ matrix.workflow-version }}
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
           OVERLEAF_EMAIL: ${{ secrets.OVERLEAF_EMAIL }}
           OVERLEAF_PASSWORD: ${{ secrets.OVERLEAF_PASSWORD }}
           GH_API_KEY: ${{ secrets.GH_API_KEY }}
-          SHOWYOURWORK_FORK: ${{ github.event.pull_request.head.repo.clone_url }}
-          SHOWYOURWORK_REF: ${{ github.event.pull_request.head.sha }}

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -112,6 +112,15 @@ def parse_syw_spec(syw_spec):
             syw_spec = {"ref": syw_spec}
         elif syw_spec in ["main", "dev"]:
             syw_spec = {"ref": syw_spec}
+        elif syw_spec.startswith("https://") or syw_spec.startswith("http://"):
+            if "@" in syw_spec:
+                fork, ref = syw_spec.split("@")
+                if "#" in ref:
+                    ref, _ = ref.split("#")
+            else:
+                fork = syw_spec
+                ref = None
+            syw_spec = {"fork": fork, "ref": ref}
         else:
             syw_spec = {"path": syw_spec}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,10 @@
+import os
 import shutil
 from pathlib import Path
 
 import pytest
+
+from showyourwork.git import get_repo_sha
 
 
 def pytest_sessionstart(session):
@@ -19,11 +22,20 @@ def pytest_addoption(parser):
         default=False,
         help="enable remote tests",
     )
+    parser.addoption(
+        "--workflow-version",
+        action="store",
+        default=get_repo_sha(),
+        help="version of showyourwork to use in showyourwork.yml",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "remote: a test that requires remote access"
+    )
+    os.environ["WORKFLOW_VERSION"] = str(
+        config.getoption("--workflow-version")
     )
 
 

--- a/tests/integration/test_letter.py
+++ b/tests/integration/test_letter.py
@@ -1,3 +1,4 @@
+import pytest
 from helpers import TemporaryShowyourworkRepository
 
 

--- a/tests/integration/test_letter.py
+++ b/tests/integration/test_letter.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from helpers import TemporaryShowyourworkRepository
 

--- a/tests/integration/test_letter.py
+++ b/tests/integration/test_letter.py
@@ -1,6 +1,10 @@
 from helpers import TemporaryShowyourworkRepository
 
 
+@pytest.mark.xfail(
+    os.getenv("WORKFLOW_VERSION") == "0.3.1",
+    reason="letter class not supported for showyourwork <= 0.3.1",
+)
 class TestLetter(TemporaryShowyourworkRepository):
     """Test setting up and building an article that uses the basic `letter` documentclass."""
 


### PR DESCRIPTION
Introduces functionality that lets us check for backwards-compatibility. Integration tests are now run using the current version of showyourwork to compile articles requesting (in `showyourwork.yml`) either the current version of the code or any previous version (defined in a build `matrix` in the Actions workflow config).