### PR TITLE
Consistent environments & Snakemake upgrade

### DIFF
--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -122,9 +122,9 @@ incomplete. When this happens, ``showyourwork`` tells the user:
 
   If you are sure that certain files are not incomplete, mark them as complete with
 
-    showyourwork build --cleanup-metadata <filenames>
+    showyourwork --cleanup-metadata <filenames>
 
-  To re-generate the files rerun showyourwork build with the --rerun-incomplete flag.
+  To re-generate the files rerun your command with the --rerun-incomplete flag.
 
 Sometimes, however, the ``--cleanup-metadata`` argument does not successfully
 clean up the incomplete files. This may be due to either an issue with Snakemake
@@ -461,3 +461,22 @@ local installation of showyourwork*.)
 
 So, if you run into this error, we recommend you download all required files directly from
 the journal and include them (making sure to ``git add`` them) in your `src/tex` folder.
+
+
+Branch rename failed
+--------------------
+
+In versions of ``showyourwork`` prior to ``0.3.2``, users may occasionally run into the
+following error when attempting to run a third party's workflow:
+
+.. code-block:: text
+  Fetching Overleaf repo...
+  error: refname refs/heads/master not found
+  fatal: Branch rename failed
+
+This is a bug in ``showyourwork`` related to the fact that the default git branch on Overleaf
+projects is called ``master``, while the default branch on GitHub is called ``main``. This
+isn't an issue unless users don't have the correct credentials to access an Overleaf repository,
+in which case the ``git clone`` silently fails and no ``master`` branch is created.
+If you run into this error, simply delete or comment out the ``overleaf:`` section of the ``environment.yml``
+workflow config and re-run the workflow.

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -389,14 +389,26 @@ build your article. You can read more about environment files
 By default, only the bare minimum specs are included
 (e.g., ``numpy`` and ``matplotlib``). Feel free to manually add to this list
 (noting that packages that can only be installed via ``pip`` should be placed in
-the ``pip`` section). It's recommended to either pin a specific version
-(i.e., ``matplotlib==3.3.4``) or specify a minimum version
-(i.e., ``matplotlib>=3.0.0``) for your packages. Just be aware that overconstrained
-requirements may break on other platforms
+the ``pip`` section). For packages listed under ``dependencies``, it is highly
+recommended that users specify **explict channels** and pin **exact versions**, e.g.:
+
+.. code-block:: text
+
+  dependencies:
+    - conda-forge::python=3.9
+
+For ``pip`` dependencies, users should also pin exact versions, e.g.:
+
+.. code-block:: text
+
+  - pip:
+    - matplotlib==3.3.4
+
+Note that overconstrained requirements may break the installation on other platforms
 (see `this post <https://stackoverflow.com/questions/39280638/how-to-share-conda-environments-across-platforms>`_),
-so you should probably only pin the direct dependencies of your project.
-If you alread have a ``conda`` environment for your project, you can export
-these direct dependencies -- the ones that you explicitly installed in the enviornment --
+so users should consider only pinning the *direct* dependencies of their project.
+If a ``conda`` environment already exists for a project, one can export
+these direct dependencies -- the ones whose installation was explicitly requested in the enviornment --
 by running
 
 .. code-block:: bash
@@ -404,8 +416,8 @@ by running
     conda env export --from-history | grep -v "^prefix: " > environment.yml
 
 The ``grep`` command removes the line in the environment file with the absolute path
-to your ``conda`` environment, which probably won't be useful to anyone else running
-your code!
+to the ``conda`` environment.
+
 
 
 .. _license:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "setuptools_scm",
         "jinja2>=2.11.1",
-        "click",
+        "click>=8.0.0",
         "pyyaml",
         "requests",
         "cookiecutter",

--- a/showyourwork/cli/__init__.py
+++ b/showyourwork/cli/__init__.py
@@ -10,4 +10,33 @@ setting. This allows users running any version of ``showyourwork`` to build any
 article.
 
 """
-from .main import entry_point
+import sys
+
+from .main import DEFAULT_SUBCOMMAND, OPTIONS, SUBCOMMANDS, main
+
+
+def entry_point():
+    """
+    Modify the call from `showyourwork ...` to `showyourwork build...`
+    if the user didn't explicitly provide a valid subcommand or option.
+
+    Click can in principle handle this (the `@click.group` decorator accepts
+    an `invoke_without_command` option) but if we do that I don't _think_
+    we can simultaneously set `ignore_unknown_options`. We need to be able
+    to forward unknown options directly to `snakemake`.
+
+    This hack allows users to call, e.g.,
+
+        showyourwork --rerun-incomplete
+
+    instead of
+
+        showyourwork build --rerun-incomplete
+
+    (the invocation they had to use previously). We allow this by injecting
+    the `build` subcommand into `sys.argv` prior to click taking control.
+
+    """
+    if len(sys.argv) == 1 or not (sys.argv[1] in SUBCOMMANDS + OPTIONS):
+        sys.argv.insert(1, DEFAULT_SUBCOMMAND)
+    main()

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -103,7 +103,7 @@ def run_in_env(command, **kwargs):
     # Users can always run `showyourwork clean --deep` to remove these dirs.
     syw_hash = hashlib.md5()
     syw_hash.update(syw_spec.encode())
-    syw_hash.hexdigest()
+    syw_hash = syw_hash.hexdigest()
     envdir = paths.user().conda / syw_hash
     if not envdir.exists():
         logger.info(

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -1,6 +1,5 @@
-import filecmp
+import hashlib
 import re
-import shutil
 import subprocess
 
 import jinja2
@@ -82,11 +81,6 @@ def run_in_env(command, **kwargs):
     if conda_version < MIN_CONDA_VERSION:
         raise exceptions.CondaVersionError(MIN_CONDA_VERSION, conda_version)
 
-    # Various conda environment files
-    workflow_envfile = paths.user().temp / "environment.yml"
-    workflow_condarc = paths.user().temp / ".condarc"
-    cached_envfile = paths.user().home_temp / "environment.yml"
-
     # Infer the `showyourwork` version from the user's config file
     if not (paths.user().repo / "showyourwork.yml").exists():
         raise exceptions.ShowyourworkException(
@@ -100,53 +94,50 @@ def run_in_env(command, **kwargs):
         .render(),
         Loader=Loader,
     )
-    syw_spec, syw_env, syw_condarc = parse_syw_spec(
-        user_config.get("version", None), return_env_and_condarc=True
-    )
+    syw_spec = parse_syw_spec(user_config.get("version", None))
 
-    # Copy the showyourwork environment file to a temp location,
-    # and add the user's requested showyourwork version as a dependency
-    # so we can import it within Snakemake
-    for dep in syw_env["dependencies"]:
-        if type(dep) is dict and "pip" in dep:
-            dep["pip"].append(syw_spec)
-            break
-    with open(workflow_envfile, "w") as f:
-        print(yaml.dump(syw_env, Dumper=Dumper), file=f)
-    with open(workflow_condarc, "w") as f:
-        print(yaml.dump(syw_condarc, Dumper=Dumper), file=f)
-
-    # Set up or update our isolated conda env
-    if not paths.user().env.exists():
-        # Set up a new env and cache the envfile
+    # Set up or update our isolated conda env. The conda env
+    # should be uniquely determined by the `syw_spec`, so we'll
+    # cache it in the user's home directory under a folder whose
+    # name is a simple MD5 hash of `syw_spec`.
+    # Users can always run `showyourwork clean --deep` to remove these dirs.
+    syw_hash = hashlib.md5()
+    syw_hash.update(syw_spec.encode())
+    syw_hash.hexdigest()
+    envdir = paths.user().conda / syw_hash
+    if not envdir.exists():
         logger.info(
-            "Creating a new conda environment in ~/.showyourwork/env..."
+            f"Creating a new conda environment in ~/.showyourwork/conda/{syw_hash}..."
         )
+
+        # Get the `environment.yml` file for this version of showyourwork
+        _, syw_env, syw_condarc = parse_syw_spec(
+            user_config.get("version", None), return_env_and_condarc=True
+        )
+
+        # Add the user's requested showyourwork version as a dependency
+        # so we can import it within Snakemake
+        for dep in syw_env["dependencies"]:
+            if type(dep) is dict and "pip" in dep:
+                dep["pip"].append(syw_spec)
+                break
+
+        # Save the `environment.yml` and `.condarc` to a temp location
+        workflow_envfile = paths.user().temp / "environment.yml"
+        workflow_condarc = paths.user().temp / ".condarc"
+        with open(workflow_envfile, "w") as f:
+            print(yaml.dump(syw_env, Dumper=Dumper), file=f)
+        with open(workflow_condarc, "w") as f:
+            print(yaml.dump(syw_condarc, Dumper=Dumper), file=f)
+
+        # Create the conda environment
         get_stdout(
-            f"CONDARC={workflow_condarc} conda env create -p {paths.user().env} -f {workflow_envfile} -q",
+            f"CONDARC={workflow_condarc} conda env create -p {envdir} -f {workflow_envfile} -q",
             shell=True,
         )
-        shutil.copy(workflow_envfile, cached_envfile)
-    else:
-        # We'll update the env based on our spec file if the current
-        # environment differs (based on checking the cached spec file)
-        if cached_envfile.exists():
-            cache_hit = filecmp.cmp(
-                cached_envfile, workflow_envfile, shallow=False
-            )
-        else:
-            cache_hit = False
-
-        if not cache_hit:
-            logger.info("Updating conda environment in ~/.showyourwork/env...")
-            get_stdout(
-                f"CONDARC={workflow_condarc} conda env update -p {paths.user().env} -f {workflow_envfile} --prune -q",
-                shell=True,
-            )
-            shutil.copy(workflow_envfile, cached_envfile)
 
     # Command to activate our environment
-    conda_activate = f"{conda_setup} && conda activate {paths.user().env}"
+    conda_activate = f"{conda_setup} && conda activate {envdir}"
 
     # Command to get the path to the showyourwork installation.
     # This is used to resolve the path to the internal Snakefile.

--- a/showyourwork/cli/conda_env.py
+++ b/showyourwork/cli/conda_env.py
@@ -118,7 +118,7 @@ def run_in_env(command, **kwargs):
         if not cache_hit:
             logger.info("Updating conda environment in ~/.showyourwork/env...")
             get_stdout(
-                f"conda env update -p {paths.user().env} -f {workflow_envfile} --prune -q",
+                f"CONDARC={paths.showyourwork().envs / '.condarc'} conda env update -p {paths.user().env} -f {workflow_envfile} --prune -q",
                 shell=True,
             )
             shutil.copy(workflow_envfile, cached_envfile)

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -8,6 +8,12 @@ import click
 from .. import __version__, exceptions, git
 from . import commands
 
+# Store command & option metadata here so we can make `build`
+# the default subcommand in __init__.py
+DEFAULT_SUBCOMMAND = "build"
+SUBCOMMANDS = ["build", "cache", "clean", "setup", "tarball"]
+OPTIONS = ["-v", "--version", "--help"]
+
 
 def ensure_top_level():
     """Ensures we're running commands in the top level of a git repo.
@@ -67,7 +73,7 @@ def echo(text="", **kwargs):
         click.echo(text, **kwargs)
 
 
-@click.group(invoke_without_command=True)
+@click.group
 @click.option(
     "-v",
     "--version",
@@ -75,7 +81,7 @@ def echo(text="", **kwargs):
     help="Show the program version and exit.",
 )
 @click.pass_context
-def entry_point(context, version):
+def main(context, version):
     """Easily build open-source, reproducible scientific articles."""
     # Parse
     if version:
@@ -85,7 +91,7 @@ def entry_point(context, version):
         context.invoke(build)
 
 
-@entry_point.command(
+@main.command(
     context_settings=dict(
         ignore_unknown_options=True,
     )
@@ -194,7 +200,7 @@ def validate_slug(context, param, slug):
         raise click.BadParameter("Must have the form `user/repo`.")
 
 
-@entry_point.command()
+@main.command()
 @click.argument("slug", callback=validate_slug, metavar="<user/repo>")
 @click.option(
     "-y",
@@ -259,7 +265,7 @@ def setup(slug, yes, quiet, cache, overleaf, ssh, version, action_spec):
     commands.setup(slug, cache, overleaf, ssh, version, action_spec)
 
 
-@entry_point.command()
+@main.command()
 @click.option(
     "-f",
     "--force",
@@ -278,7 +284,7 @@ def clean(force, deep):
     commands.clean(force, deep)
 
 
-@entry_point.command()
+@main.command()
 def tarball():
     """Generate a tarball of the build in the current working directory."""
     ensure_top_level()
@@ -286,7 +292,7 @@ def tarball():
     commands.tarball()
 
 
-@entry_point.group()
+@main.group()
 @click.pass_context
 def cache(ctx):
     """Caching-related operations."""

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -99,7 +99,7 @@ def get_run_type():
 
 def get_env_and_condarc_from_pip(version):
     return get_env_and_condarc_from_git(
-        "https://github.com/showyourwork/showyourwork", ref=version
+        "https://github.com/showyourwork/showyourwork", ref=f"v{version}"
     )
 
 

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -113,11 +113,11 @@ def get_env_and_condarc_from_path(path):
             / "environment.yml",
             "r",
         ) as f:
-            env = f.read()
+            env = yaml.load(f, Loader=Loader)
         with open(
             Path(path) / "showyourwork" / "workflow" / "envs" / ".condarc", "r"
         ) as f:
-            condarc = f.read()
+            condarc = yaml.load(f, Loader=Loader)
     except:
         raise exceptions.ShowyourworkNotFoundError(path)
     return env, condarc
@@ -133,12 +133,12 @@ def get_env_and_condarc_from_git(url, ref="main"):
             f"https://raw.githubusercontent.com/{user}/{repo}/{ref}/"
             "showyourwork/workflow/envs/environment.yml"
         ) as f:
-            env = f.read().decode("utf-8")
+            env = yaml.load(f, Loader=Loader)
         with urllib.request.urlopen(
             f"https://raw.githubusercontent.com/{user}/{repo}/{ref}/"
             "showyourwork/workflow/envs/.condarc"
         ) as f:
-            condarc = f.read().decode("utf-8")
+            condarc = yaml.load(f, Loader=Loader)
     except:
         raise exceptions.RequestError(
             message=f"Unable to retrieve environment info from `{url}@{ref}`."

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -1,11 +1,13 @@
 import os
 import re
+import urllib.request
 from collections import ChainMap, OrderedDict
 from contextlib import contextmanager
 from pathlib import Path
 
 import jinja2
 import yaml
+from lastversion import latest
 
 from . import exceptions, git, paths
 
@@ -95,18 +97,68 @@ def get_run_type():
     return os.getenv("SNAKEMAKE_RUN_TYPE", "other")
 
 
-def parse_syw_spec(syw_spec):
+def get_env_and_condarc_from_pip(version):
+    return get_env_and_condarc_from_git(
+        "https://github.com/showyourwork/showyourwork", ref=version
+    )
+
+
+def get_env_and_condarc_from_path(path):
+    try:
+        with open(
+            Path(path)
+            / "showyourwork"
+            / "workflow"
+            / "envs"
+            / "environment.yml",
+            "r",
+        ) as f:
+            env = f.read()
+        with open(
+            Path(path) / "showyourwork" / "workflow" / "envs" / ".condarc", "r"
+        ) as f:
+            condarc = f.read()
+    except:
+        raise exceptions.ShowyourworkNotFoundError(path)
+    return env, condarc
+
+
+def get_env_and_condarc_from_git(url, ref="main"):
+    try:
+        user, repo = re.match(
+            "http(?:s)?://(?:www.)?github.com/(.*?)/(.*?)(?:.git)?(?:/.*?)?$",
+            url,
+        ).groups()
+        with urllib.request.urlopen(
+            f"https://raw.githubusercontent.com/{user}/{repo}/{ref}/"
+            "showyourwork/workflow/envs/environment.yml"
+        ) as f:
+            env = f.read().decode("utf-8")
+        with urllib.request.urlopen(
+            f"https://raw.githubusercontent.com/{user}/{repo}/{ref}/"
+            "showyourwork/workflow/envs/.condarc"
+        ) as f:
+            condarc = f.read().decode("utf-8")
+    except:
+        raise exceptions.RequestError(
+            message=f"Unable to retrieve environment info from `{url}@{ref}`."
+        )
+    return env, condarc
+
+
+def parse_syw_spec(syw_spec, return_env_and_condarc=False):
     """
     Resolve the version of showyourwork from the value provided in the config.
 
     """
-    # No specific version provided; default to any
+    # No specific version provided; default to latest release
     if not syw_spec:
-        return "showyourwork"
-
+        syw_spec = {
+            "pip": str(latest("https://pypi.org/project/showyourwork"))
+        }
     # For backwards compatibility, parse the version string into a structured
     # spec that we understand
-    if isinstance(syw_spec, str):
+    elif isinstance(syw_spec, str):
         if re.match(r"(?:(\d+\.[.\d]*\d+))", syw_spec):
             syw_spec = {"pip": syw_spec}
         elif re.match("[0-9a-f]{5,40}", syw_spec):
@@ -128,6 +180,8 @@ def parse_syw_spec(syw_spec):
     if "pip" in syw_spec:
         version = syw_spec.pop("pip")
         solved = f"showyourwork=={version}"
+        if return_env_and_condarc:
+            env_and_condarc = get_env_and_condarc_from_pip(version)
     elif "path" in syw_spec:
         path = syw_spec.pop("path")
         if not Path(path).is_absolute():
@@ -137,6 +191,8 @@ def parse_syw_spec(syw_spec):
         if not path.exists():
             raise exceptions.ShowyourworkNotFoundError(path)
         solved = f"-e {path}"
+        if return_env_and_condarc:
+            env_and_condarc = get_env_and_condarc_from_path(path)
     else:
         fork = syw_spec.pop(
             "fork", "https://github.com/showyourwork/showyourwork.git"
@@ -144,8 +200,12 @@ def parse_syw_spec(syw_spec):
         spec = syw_spec.pop("ref", None)
         if not spec:
             solved = f"git+{fork}#egg=showyourwork"
+            if return_env_and_condarc:
+                env_and_condarc = get_env_and_condarc_from_git(fork)
         else:
             solved = f"git+{fork}@{spec}#egg=showyourwork"
+            if return_env_and_condarc:
+                env_and_condarc = get_env_and_condarc_from_git(fork, ref=spec)
 
     if syw_spec:
         raise exceptions.ShowyourworkException(
@@ -154,7 +214,10 @@ def parse_syw_spec(syw_spec):
             f"invalid) fields were also set: {syw_spec}"
         )
 
-    return solved
+    if return_env_and_condarc:
+        return solved, *env_and_condarc
+    else:
+        return solved
 
 
 def as_dict(x, depth=0, maxdepth=30):

--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
@@ -1,6 +1,6 @@
 dependencies:
-  - numpy=1.19.2
-  - pip=21.0.1
-  - python=3.9
+  - conda-forge::numpy=1.19.2
+  - conda-forge::pip=21.0.1
+  - conda-forge::python=3.9
   - pip:
       - matplotlib==3.4.3

--- a/showyourwork/exceptions/other.py
+++ b/showyourwork/exceptions/other.py
@@ -17,6 +17,14 @@ class CondaNotFoundError(ShowyourworkException):
         )
 
 
+class CondaVersionError(ShowyourworkException):
+    def __init__(self, min_version, version="[unknown]"):
+        super().__init__(
+            f"Showyourwork requires conda version {min_version} or greater, "
+            f"but version {version} is installed. Please upgrade conda."
+        )
+
+
 class ShowyourworkNotFoundError(ShowyourworkException):
     def __init__(self, path):
         super().__init__(

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -394,7 +394,10 @@ def patch_snakemake_wait_for_files():
                     )
                     else os.path.exists(f)
                     if not (
-                        (is_flagged(f, "pipe") or is_flagged(f, "service"))
+                        (
+                            snakemake.io.is_flagged(f, "pipe")
+                            or snakemake.io.is_flagged(f, "service")
+                        )
                         and ignore_pipe_or_service
                     )
                     else True

--- a/showyourwork/patches.py
+++ b/showyourwork/patches.py
@@ -32,9 +32,7 @@ class SnakemakeFormatter(logging.Formatter):
     """
 
     replacements = {
-        "snakemake --cleanup-metadata": "showyourwork build --cleanup-metadata",
-        "rerun your command with the --rerun-incomplete flag": "rerun showyourwork build with the --rerun-incomplete flag",
-        "It can be removed with the --unlock argument": "It can be removed by passing --unlock to showyourwork build",
+        "snakemake --cleanup-metadata": "showyourwork --cleanup-metadata",
     }
 
     def format(self, record):
@@ -375,7 +373,10 @@ def patch_snakemake_wait_for_files():
     """
 
     def wait_for_files(
-        files, latency_wait=3, force_stay_on_remote=False, ignore_pipe=False
+        files,
+        latency_wait=3,
+        force_stay_on_remote=False,
+        ignore_pipe_or_service=False,
     ):
         """Wait for given files to be present in the filesystem."""
         files = list(files)
@@ -392,7 +393,10 @@ def patch_snakemake_wait_for_files():
                         and (force_stay_on_remote or f.should_stay_on_remote)
                     )
                     else os.path.exists(f)
-                    if not (snakemake.io.is_flagged(f, "pipe") and ignore_pipe)
+                    if not (
+                        (is_flagged(f, "pipe") or is_flagged(f, "service"))
+                        and ignore_pipe_or_service
+                    )
                     else True
                 )
             ]

--- a/showyourwork/paths.py
+++ b/showyourwork/paths.py
@@ -54,7 +54,8 @@ class user:
         # User home temp (for all repos)
         self.home_temp = Path.home() / ".showyourwork"
         self.home_temp.mkdir(exist_ok=True)
-        self.env = self.home_temp / "env"
+        self.conda = self.home_temp / "conda"
+        self.conda.mkdir(exist_ok=True)
 
         # Temporary paths
         self.temp = self.repo / ".showyourwork"

--- a/showyourwork/userrules.py
+++ b/showyourwork/userrules.py
@@ -52,16 +52,8 @@ def process_user_rules():
         if not ur.message:
             ur.message = f"Running user rule {ur.name}..."
 
-        # Add script as an explicit input
-        if ur.script:
-            script = ur.script
-            script = script.replace("{wildcards.", "{")
-            ur.set_input(script)
-        elif ur.notebook:
-            notebook = ur.notebook
-            notebook = notebook.replace("{wildcards.", "{")
-            ur.set_input(notebook)
-        elif ur.is_run:
+        # Disallow `run` directives: enforce scripts!
+        if ur.is_run:
             raise exceptions.RunDirectiveNotAllowedInUserRules(ur.name)
 
         # Record any cached output

--- a/showyourwork/workflow/envs/.condarc
+++ b/showyourwork/workflow/envs/.condarc
@@ -1,5 +1,4 @@
 channels:
   - defaults
   - conda-forge
-  - bioconda
-channel_priority: false
+channel_priority: true

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -1,14 +1,14 @@
 dependencies:
-  - python=3.9
-  - pip=21.0.1
+  - conda-forge::python=3.9
+  - conda-forge::pip=21.0.1
   - conda-forge::tectonic=0.8.0
-  - conda-forge::mamba=0.23.3
-  - bioconda::snakemake-minimal=6.15.5
-  - conda-forge::imagemagick
-  - graphviz
+  - conda-forge::mamba=0.25.0
+  - conda-forge::imagemagick=7.1.0.27
+  - conda-forge::datrie=0.8.2
   - pip:
       - click==8.0.4
       - pyyaml==6.0
       - requests==2.25.1
       - jinja2==3.0.3
       - graphviz==0.19.1
+      - snakemake==6.15.5

--- a/showyourwork/workflow/envs/environment.yml
+++ b/showyourwork/workflow/envs/environment.yml
@@ -11,4 +11,4 @@ dependencies:
       - requests==2.25.1
       - jinja2==3.0.3
       - graphviz==0.19.1
-      - snakemake==6.15.5
+      - snakemake==7.14.2

--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -52,7 +52,7 @@
 
 % Showyourwork logo
 \newcommand{\showyourwork}{%
-  \smash{\raisebox{-1.7ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
+  \smash{\raisebox{-1.4ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
 }
 
 % Define custom colors

--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -433,17 +433,26 @@ def get_json_tree():
     ]
 
     # Separate into dynamic and static figures
-    free_floating_static = [
-        graphic
-        for graphic in free_floating_graphics
-        if (paths.user().repo / graphic).parents[0] == paths.user().figures
-        and (paths.user().static / Path(graphic).name).exists()
-    ]
-    free_floating_dynamic = [
-        graphic
-        for graphic in free_floating_graphics
-        if graphic not in free_floating_static
-    ]
+    free_floating_static = list(
+        set(
+            [
+                graphic
+                for graphic in free_floating_graphics
+                if (paths.user().repo / graphic).parents[0]
+                == paths.user().figures
+                and (paths.user().static / Path(graphic).name).exists()
+            ]
+        )
+    )
+    free_floating_dynamic = list(
+        set(
+            [
+                graphic
+                for graphic in free_floating_graphics
+                if graphic not in free_floating_static
+            ]
+        )
+    )
 
     # Add entries to the tree: dynamic figures
     # (User should provide a custom Snakemake rule)

--- a/tests/unit/test_parse_syw_spec.py
+++ b/tests/unit/test_parse_syw_spec.py
@@ -7,7 +7,6 @@ from showyourwork.exceptions import ShowyourworkException
 @pytest.mark.parametrize(
     "spec,expected",
     [
-        (None, "showyourwork"),
         ("0.3.0", "showyourwork==0.3.0"),
         (
             "893eda2",


### PR DESCRIPTION
This is an alternative solution to that provided in #203. The source of all our problems with backwards compatibility is the fact that we are using this [environment file](https://github.com/showyourwork/showyourwork/blob/22cbcdfca0c77c0fbd4e929f2f29dc2a52274eb2/showyourwork/workflow/envs/environment.yml) when setting up the conda environment for the article workflow. This is a problem because the article defines its own version of `showyourwork` (in the `showyourwork.yml` file), but we're using the environment specs defined in the _currently installed_ version of `showyourwork`. When these differ, we can run into issues like the ones discussed in #203.

Rather than fork Snakemake and monkeypatch our way to backwards compatibility, I suggest we instead focus on installing the correct dependencies in the first place. I guess this sound obvious in hindsight, but it's going to require a little sleight of hand to implement.

More soon.