### PR TITLE
Test against 0.3.1.post1

### DIFF
--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         workflow-version:
           - ${{ (github.event_name == 'push' && github.sha) || format('{0}@{1}', github.event.pull_request.head.repo.clone_url, github.event.pull_request.head.sha) }}
-          - 0.3.1
+          - 0.3.1.post1
         action-spec:
           - ${{ (github.event_name == 'push' && format('git+https://github.com/showyourwork/showyourwork.git@{0}#egg=showyourwork', github.sha)) || format('git+{0}@{1}#egg=showyourwork', github.event.pull_request.head.repo.clone_url, github.event.pull_request.head.sha) }}
     steps:


### PR DESCRIPTION
Version `0.3.1` is permanently broken because of #215. Now testing against `0.3.1.post1`.