### PR TITLE
Fix `Illegal parameter` error in minimal `showyourwork.sty`

### DIFF
--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/showyourwork.sty
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/showyourwork.sty
@@ -9,5 +9,5 @@
     \newcommand\GitHubIcon{}
     \newcommand\showyourwork{}
     \newcommand\script[1]{}
-    \newcommand\variable[1]{\input{#1}}
+    \newcommand\variable[1]{\input{##1}}
 }


### PR DESCRIPTION
Right now, compiling the Overleaf equivalent of a showyourwork repo, you will see the (non-breaking) error:
```
Illegal parameter number in definition of \reserved@a.
<to be read again> 
```
The solution is to use `##1` instead of `#1` in command definitions.

See https://tex.stackexchange.com/a/639980: 

> \IfFileExists doesn't work like “usual” conditionals: it stores the true and false branches in macros, and uses them later. This requires you to double every # in there:

