### PR TITLE
Updating the zenodo docs to detail how to access cached directories

### DIFF
--- a/docs/zenodo.rst
+++ b/docs/zenodo.rst
@@ -333,7 +333,7 @@ users with access to your account can see their files.
                 "src/figures/figure.pdf"
             script:
                 "src/scripts/figure.py"
-    
+
     You will also need to update the ``showyourwork.yml`` config file to reflect
     the new dependency.
 

--- a/docs/zenodo.rst
+++ b/docs/zenodo.rst
@@ -321,7 +321,7 @@ users with access to your account can see their files.
     directory and upload the archive to Zenodo Sandbox, then download and unzip
     it the next time it is needed.
 
-    Scripts that use the files in this output directory can have their rule 
+    Scripts that use the files in this output directory can have their rule
     inputs point directly to the directory itself.
 
     .. code-block:: python
@@ -334,7 +334,7 @@ users with access to your account can see their files.
             script:
                 "src/scripts/figure.py"
 
-    You will also need to update the ``showyourwork.yml`` config file to 
+    You will also need to update the ``showyourwork.yml`` config file to
     reflect the dependency on the *directory*, rather than the individual files.
 
     .. code-block:: yaml

--- a/docs/zenodo.rst
+++ b/docs/zenodo.rst
@@ -321,21 +321,21 @@ users with access to your account can see their files.
     directory and upload the archive to Zenodo Sandbox, then download and unzip
     it the next time it is needed.
 
-    You will also need to update the rule for any scripts that use the output
-    from this directory to take the rule ouput as an input.
+    Scripts that use the files in this output directory can have their rule 
+    inputs point directly to the directory itself.
 
     .. code-block:: python
 
         rule figure:
             input:
-                rules.simulation.output
+                "src/data/simulation"
             output:
                 "src/figures/figure.pdf"
             script:
                 "src/scripts/figure.py"
 
-    You will also need to update the ``showyourwork.yml`` config file to reflect
-    the new dependency.
+    You will also need to update the ``showyourwork.yml`` config file to 
+    reflect the dependency on the *directory*, rather than the individual files.
 
     .. code-block:: yaml
         :caption: **File:** ``showyourwork.yml``

--- a/docs/zenodo.rst
+++ b/docs/zenodo.rst
@@ -321,6 +321,30 @@ users with access to your account can see their files.
     directory and upload the archive to Zenodo Sandbox, then download and unzip
     it the next time it is needed.
 
+    You will also need to update the rule for any scripts that use the output
+    from this directory to take the rule ouput as an input.
+
+    .. code-block:: python
+
+        rule figure:
+            input:
+                rules.simulation.output
+            output:
+                "src/figures/figure.pdf"
+            script:
+                "src/scripts/figure.py"
+    
+    You will also need to update the ``showyourwork.yml`` config file to reflect
+    the new dependency.
+
+    .. code-block:: yaml
+        :caption: **File:** ``showyourwork.yml``
+
+        dependencies:
+            src/scripts/figure.py:
+                - src/data/simulation/
+
+
     .. raw:: html
 
         <br/>


### PR DESCRIPTION
Just a small update to the docs to be more explicit about how to update the rules and dependencies when working with cached directories in Zenodo, as discussed in #246.