### PR TITLE
Protected the \nolinenumbers command

### DIFF
--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/aastex631.cls
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/aastex631.cls
@@ -6233,7 +6233,7 @@ on page
 %% text to listoftables or listoffigures, which we are not going to use
 %% anyway. This change enables track changes commands to work in captions.
 \def\xtable{table}
-\def\caption{\ifnumlines\nolinenumbers\fi 
+\def\caption{\ifnumlines\nolinenumbers\fi
 \ifx\@captype\@undefined
 \@latex@error {\noexpand \caption outside float}\@ehd
 \expandafter \@gobble \else

--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/aastex631.cls
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/aastex631.cls
@@ -6233,7 +6233,7 @@ on page
 %% text to listoftables or listoffigures, which we are not going to use
 %% anyway. This change enables track changes commands to work in captions.
 \def\xtable{table}
-\def\caption{\nolinenumbers % 2021 Oct 27 Rodrigo Luger
+\def\caption{\ifnumlines\nolinenumbers\fi 
 \ifx\@captype\@undefined
 \@latex@error {\noexpand \caption outside float}\@ehd
 \expandafter \@gobble \else


### PR DESCRIPTION
The \nolinenumbers command is defined by the lineno package that isn't required, added the conditional check for the \numlines flag defined when lineno is imported