### PR TITLE
Escape paths in all subprocess calls to handle spaces

### DIFF
--- a/showyourwork/cli/commands/build.py
+++ b/showyourwork/cli/commands/build.py
@@ -15,8 +15,8 @@ def build(snakemake_args=[]):
 
     """
     snakefile = paths.showyourwork().workflow / "build.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE={paths.user().cache} SNAKEMAKE_RUN_TYPE='build' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f"{snakemake} {' '.join(snakemake_args)} -s {snakefile}"
+    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='build' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
+    command = f"{snakemake} {' '.join(snakemake_args)} -s \"{snakefile}\""
     result = subprocess.run(command, shell=True, check=False)
     if result.returncode > 0:
         os._exit(1)

--- a/showyourwork/cli/commands/clean.py
+++ b/showyourwork/cli/commands/clean.py
@@ -17,9 +17,9 @@ def clean(force, deep, options=""):
         shutil.rmtree(paths.user().repo / ".snakemake" / "incomplete")
     for file in ["build.smk", "prep.smk"]:
         snakefile = paths.showyourwork().workflow / file
-        snakemake = f"SNAKEMAKE_OUTPUT_CACHE={paths.user().cache} SNAKEMAKE_RUN_TYPE='clean' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-        command = f"{snakemake} {options} -s {snakefile} --delete-all-output"
-        result = subprocess.run(command, shell=True, check=False)
+        snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='clean' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
+        command = f'{snakemake} {options} -s "{snakefile}" --delete-all-output'
+        subprocess.run(command, shell=True, check=False)
     if (paths.user().repo / "arxiv.tar.gz").exists():
         (paths.user().repo / "arxiv.tar.gz").unlink()
     if paths.user().temp.exists():

--- a/showyourwork/cli/commands/preprocess.py
+++ b/showyourwork/cli/commands/preprocess.py
@@ -11,8 +11,8 @@ def preprocess(snakemake_args=[]):
         snakemake_args (list, optional): Additional options to pass to Snakemake.
     """
     snakefile = paths.showyourwork().workflow / "prep.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE={paths.user().cache} SNAKEMAKE_RUN_TYPE='preprocess' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f"{snakemake} {' '.join(snakemake_args)} -s {snakefile}"
+    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='preprocess' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
+    command = f"{snakemake} {' '.join(snakemake_args)} -s \"{snakefile}\""
     result = subprocess.run(command, shell=True, check=False)
     if result.returncode > 0:
         os._exit(1)

--- a/showyourwork/cli/commands/tarball.py
+++ b/showyourwork/cli/commands/tarball.py
@@ -11,8 +11,8 @@ def tarball(options=""):
         options (str, optional): Additional options to pass to Snakemake.
     """
     snakefile = paths.showyourwork().workflow / "build.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE={paths.user().cache} SNAKEMAKE_RUN_TYPE='tarball' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f"{snakemake} {options} -s {snakefile} syw__arxiv_entrypoint"
+    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='tarball' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
+    command = f'{snakemake} {options} -s "{snakefile}" syw__arxiv_entrypoint'
     result = subprocess.run(command, shell=True, check=False)
     if result.returncode > 0:
         os._exit(1)

--- a/showyourwork/cli/commands/zenodo.py
+++ b/showyourwork/cli/commands/zenodo.py
@@ -1,6 +1,6 @@
 import os
 
-from ... import exceptions, logging, paths
+from ... import exceptions, logging
 from ...config import edit_yaml
 from ...git import get_repo_branch
 from ...zenodo import Zenodo
@@ -22,7 +22,7 @@ def zenodo_publish(branch):
         with edit_yaml("zenodo.yml") as config:
             sandbox_doi = config["cache"][branch]["sandbox"]
             assert sandbox_doi is not None
-    except:
+    except Exception:
         raise exceptions.ShowyourworkException(
             f"Zenodo Sandbox deposit not found for branch {branch}."
         )
@@ -68,7 +68,7 @@ def zenodo_freeze(branch):
         with edit_yaml("zenodo.yml") as config:
             doi = config["cache"][branch]["sandbox"]
             assert doi is not None
-    except:
+    except Exception:
         raise exceptions.ShowyourworkException(
             f"Zenodo Sandbox deposit not found for branch {branch}."
         )
@@ -97,7 +97,7 @@ def zenodo_create(branch):
         raise exceptions.ShowyourworkException(
             f"Branch {branch} already has an associated Zenodo Sandbox deposit."
         )
-    except:
+    except Exception:
         pass
     deposit = Zenodo("sandbox", branch=branch)
     with edit_yaml("zenodo.yml") as config:
@@ -113,14 +113,13 @@ def zenodo_delete(branch):
     Args:
         branch (str): Branch whose cahce is to be deleted.
     """
-    logger = logging.get_logger()
     if branch is None:
         branch = get_repo_branch()
     try:
         with edit_yaml("zenodo.yml") as config:
             doi = config["cache"][branch]["sandbox"]
             assert doi is not None
-    except:
+    except Exception:
         raise exceptions.ShowyourworkException(
             f"Zenodo Sandbox deposit not found for branch {branch}."
         )

--- a/showyourwork/overleaf.py
+++ b/showyourwork/overleaf.py
@@ -500,11 +500,11 @@ def pull_files(
         # Ensure there are no uncommitted changes to the local file/directory
         try:
             get_stdout(
-                f"git diff --quiet -- {file}",
+                f'git diff --quiet -- "{file}"',
                 shell=True,
                 cwd=paths.user(path=path).repo,
             )
-        except:
+        except Exception:
             msg = (
                 "Uncommitted changes to local file: "
                 f"{remote_file.relative_to(paths.user(path=path).overleaf)}. "
@@ -526,12 +526,12 @@ def pull_files(
 
         try:
             get_stdout(
-                f"git log -n 1 --pretty=format:%s -- {file}",
+                f'git log -n 1 --pretty=format:%s -- "{file}"',
                 shell=True,
                 cwd=paths.user(path=path).repo,
                 callback=callback,
             )
-        except:
+        except Exception:
             msg = (
                 "Local file changed since the last Overleaf sync: "
                 f"{remote_file.relative_to(paths.user(path=path).overleaf)}. "

--- a/showyourwork/subproc.py
+++ b/showyourwork/subproc.py
@@ -70,7 +70,7 @@ def parse_request(r):
     # Try to get the data
     try:
         data = r.json()
-    except:
+    except Exception:
         if len(r.text) == 0:
             # We're good; there's just no data
             data = {}

--- a/showyourwork/tex.py
+++ b/showyourwork/tex.py
@@ -36,7 +36,7 @@ def compile_tex(config, output_dir=None, args=[], stylesheet=None):
         "--keep-logs",
         "--keep-intermediates",
         "-o",
-        str(output_dir),
+        f'"{output_dir}"',
     ]
 
     def callback(code, stdout, stderr):
@@ -59,7 +59,7 @@ def compile_tex(config, output_dir=None, args=[], stylesheet=None):
     conda_activate = open(paths.user().flags / "SYW__CONDA", "r").read()
 
     get_stdout(
-        f"{conda_activate} tectonic {' '.join(args)} {' '.join(force_args)} {' '.join(config['user_args'])} {paths.user().repo / config['ms_tex']}",
+        f"{conda_activate} tectonic {' '.join(args)} {' '.join(force_args)} {' '.join(config['user_args'])} \"{paths.user().repo / config['ms_tex']}\"",
         shell=True,
         callback=callback,
     )

--- a/showyourwork/workflow/scripts/conda.py
+++ b/showyourwork/workflow/scripts/conda.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
                 .stdout.decode()
                 .replace("\n", "")
             )
-            conda_activate = f". {conda_prefix}/etc/profile.d/conda.sh && conda activate {env} && "
+            conda_activate = f'. {conda_prefix}/etc/profile.d/conda.sh && conda activate "{env}" && '
             break
     else:
         conda_activate = ""

--- a/showyourwork/workflow/scripts/render_dag.py
+++ b/showyourwork/workflow/scripts/render_dag.py
@@ -5,9 +5,8 @@ Generates a directed acyclic graph (DAG) of the build process.
 from pathlib import Path
 
 import graphviz
-from jinja2 import BaseLoader, Environment
 
-from showyourwork import exceptions, paths
+from showyourwork import paths
 from showyourwork.subproc import get_stdout
 from showyourwork.zenodo import get_dataset_dois
 
@@ -48,17 +47,17 @@ def convert_to_png(file):
 
         aspect = float(
             get_stdout(
-                f'{conda_activate} convert {file} -format "%[fx:w/h]" info:',
+                f'{conda_activate} convert "{file}" -format "%[fx:w/h]" info:',
                 shell=True,
             )
         )
         width = aspect * 500
         get_stdout(
             f"{conda_activate} convert -resize {width}x500 -background white -alpha remove "
-            f"-bordercolor black -border 15 {file} {file}.png",
+            f'-bordercolor black -border 15 "{file}" "{file}.png"',
             shell=True,
         )
-    except:
+    except Exception:
         return None
     else:
         return aspect

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from showyourwork.git import get_repo_sha
-
 
 def pytest_sessionstart(session):
     # Clean the sandbox

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -14,7 +14,6 @@ from showyourwork.logging import get_logger
 from showyourwork.subproc import get_stdout
 from showyourwork.zenodo import Zenodo
 
-
 # Folder where we'll create our temporary repos
 SANDBOX = Path(__file__).absolute().parents[1] / "sandbox"
 RESOURCES = Path(__file__).absolute().parents[1] / "resources"

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -7,22 +7,12 @@ import shutil
 from pathlib import Path
 
 import pytest
-import yaml
 
-import showyourwork
 from showyourwork import gitapi
 from showyourwork.config import render_config
-from showyourwork.git import get_repo_sha
 from showyourwork.logging import get_logger
 from showyourwork.subproc import get_stdout
 from showyourwork.zenodo import Zenodo
-
-try:
-    from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
-except ImportError:
-    # If LibYAML not installed
-    from yaml import Dumper, Loader
 
 
 # Folder where we'll create our temporary repos
@@ -40,6 +30,7 @@ class TemporaryShowyourworkRepository:
     debug = os.getenv("DEBUG", "False").lower() in ("true", "1", "t")
 
     # Editable class settings
+    root_path = SANDBOX
     cache = False
     overleaf_id = None
     action_wait = 240
@@ -64,7 +55,7 @@ class TemporaryShowyourworkRepository:
 
     @property
     def cwd(self):
-        return SANDBOX / self.repo
+        return self.root_path / self.repo
 
     def startup(self):
         """Subclass me to run things at startup."""
@@ -87,6 +78,9 @@ class TemporaryShowyourworkRepository:
         # Delete any local repos
         self.delete_local()
 
+        # Make the sandbox path if it doesn't exist
+        self.root_path.mkdir(exist_ok=True, parents=True)
+
         # Parse options
         command = "showyourwork setup"
         options = f"--quiet --action-spec={os.getenv('ACTION_SPEC')} "
@@ -101,12 +95,12 @@ class TemporaryShowyourworkRepository:
         if os.getenv("CI", "false") == "true":
             get_stdout(
                 "git config --global user.name 'gh-actions'",
-                cwd=SANDBOX,
+                cwd=self.root_path,
                 shell=True,
             )
             get_stdout(
                 "git config --global user.email 'gh-actions'",
-                cwd=SANDBOX,
+                cwd=self.root_path,
                 shell=True,
             )
 
@@ -116,7 +110,7 @@ class TemporaryShowyourworkRepository:
         )
         get_stdout(
             f"{command} {options} showyourwork/{self.repo}",
-            cwd=SANDBOX,
+            cwd=self.root_path,
             shell=True,
         )
 

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -7,7 +7,6 @@ from helpers import (
 )
 
 from showyourwork.config import edit_yaml
-from showyourwork.git import get_commit_message
 from showyourwork.subproc import get_stdout
 
 pytestmark = pytest.mark.remote

--- a/tests/integration/test_missing_inputs.py
+++ b/tests/integration/test_missing_inputs.py
@@ -3,8 +3,6 @@ from helpers import (
     TemporaryShowyourworkRepository,
 )
 
-from showyourwork import exceptions
-
 
 class TestMissingScript(
     TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
@@ -25,7 +23,7 @@ class TestMissingScript(
         try:
             super().build_local()
         except Exception as e:
-            if not "src/scripts/test_figure.py" in str(e):
+            if "src/scripts/test_figure.py" not in str(e):
                 raise Exception(f"Incorrect exception message: {str(e)}")
         else:
             raise Exception(
@@ -60,7 +58,7 @@ class TestDeletedScript(
         try:
             super().build_local()
         except Exception as e:
-            if not "src/scripts/test_figure.py" in str(e):
+            if "src/scripts/test_figure.py" not in str(e):
                 raise Exception(f"Incorrect exception message: {str(e)}")
         else:
             raise Exception(

--- a/tests/integration/test_space_in_path.py
+++ b/tests/integration/test_space_in_path.py
@@ -1,0 +1,9 @@
+from helpers import TemporaryShowyourworkRepository
+from helpers.temp_repo import SANDBOX
+
+
+class TestSpaceInPath(TemporaryShowyourworkRepository):
+    """Test for issues when local path has a space."""
+
+    local_build_only = True
+    root_path = SANDBOX / "space in path"


### PR DESCRIPTION
This is still pretty brittle and it would probably be better to remove some of these `shell=True` calls... But for now it should do the trick!

Closes #257 