### PR TITLE
Exposing multicore execution and mamba frontend by passing arguments to snakemake

### DIFF
--- a/showyourwork/cli/commands/build.py
+++ b/showyourwork/cli/commands/build.py
@@ -1,10 +1,8 @@
-import os
-import subprocess
-
 from ... import paths
+from .run_snakemake import run_snakemake
 
 
-def build(snakemake_args=[]):
+def build(snakemake_args=[], cores=1, conda_frontend="conda"):
     """Build the article.
 
     This function builds the article PDF by running ``Snakemake`` in an isolated
@@ -15,8 +13,11 @@ def build(snakemake_args=[]):
 
     """
     snakefile = paths.showyourwork().workflow / "build.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='build' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f"{snakemake} {' '.join(snakemake_args)} -s \"{snakefile}\""
-    result = subprocess.run(command, shell=True, check=False)
-    if result.returncode > 0:
-        os._exit(1)
+    run_snakemake(
+        snakefile.as_posix(),
+        run_type="build",
+        cores=cores,
+        conda_frontend=conda_frontend,
+        extra_args=snakemake_args,
+        check=True,
+    )

--- a/showyourwork/cli/commands/clean.py
+++ b/showyourwork/cli/commands/clean.py
@@ -1,10 +1,10 @@
 import shutil
-import subprocess
 
 from ... import paths
+from .run_snakemake import run_snakemake
 
 
-def clean(force, deep, options=""):
+def clean(force, deep, snakemake_args=[], cores=1, conda_frontend="conda"):
     """Clean the article build.
 
     Args:
@@ -17,9 +17,14 @@ def clean(force, deep, options=""):
         shutil.rmtree(paths.user().repo / ".snakemake" / "incomplete")
     for file in ["build.smk", "prep.smk"]:
         snakefile = paths.showyourwork().workflow / file
-        snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='clean' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-        command = f'{snakemake} {options} -s "{snakefile}" --delete-all-output'
-        subprocess.run(command, shell=True, check=False)
+        run_snakemake(
+            snakefile.as_posix(),
+            run_type="clean",
+            cores=cores,
+            conda_frontend=conda_frontend,
+            extra_args=list(snakemake_args) + ["--delete-all-output"],
+            check=False,
+        )
     if (paths.user().repo / "arxiv.tar.gz").exists():
         (paths.user().repo / "arxiv.tar.gz").unlink()
     if paths.user().temp.exists():

--- a/showyourwork/cli/commands/preprocess.py
+++ b/showyourwork/cli/commands/preprocess.py
@@ -1,18 +1,19 @@
-import os
-import subprocess
-
 from ... import paths
+from .run_snakemake import run_snakemake
 
 
-def preprocess(snakemake_args=[]):
+def preprocess(snakemake_args=[], cores=1, conda_frontend="conda"):
     """Pre-processing step for the article build.
 
     Args:
         snakemake_args (list, optional): Additional options to pass to Snakemake.
     """
     snakefile = paths.showyourwork().workflow / "prep.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='preprocess' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f"{snakemake} {' '.join(snakemake_args)} -s \"{snakefile}\""
-    result = subprocess.run(command, shell=True, check=False)
-    if result.returncode > 0:
-        os._exit(1)
+    run_snakemake(
+        snakefile.as_posix(),
+        run_type="preprocess",
+        cores=cores,
+        conda_frontend=conda_frontend,
+        extra_args=snakemake_args,
+        check=True,
+    )

--- a/showyourwork/cli/commands/run_snakemake.py
+++ b/showyourwork/cli/commands/run_snakemake.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import subprocess
+import sys
 
 from ... import paths
 

--- a/showyourwork/cli/commands/run_snakemake.py
+++ b/showyourwork/cli/commands/run_snakemake.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import subprocess
+
+from ... import paths
+
+
+def run_snakemake(
+    snakefile,
+    run_type=None,
+    cores=1,
+    conda_frontend="conda",
+    extra_args=[],
+    check=True,
+):
+    env = dict(os.environ)
+    env["SNAKEMAKE_OUTPUT_CACHE"] = paths.user().cache.as_posix()
+    if run_type is not None:
+        env["SNAKEMAKE_RUN_TYPE"] = run_type
+    cmd = [
+        "snakemake",
+        "--cores",
+        f"{cores}",
+        "--use-conda",
+        "--conda-frontend",
+        conda_frontend,
+        "--reason",
+        "--cache",
+        "-s",
+        snakefile,
+    ] + list(extra_args)
+    result = subprocess.run(cmd, env=env, check=False)
+    if check and result.returncode:
+        sys.exit(result.returncode)
+    return result.returncode

--- a/showyourwork/cli/commands/tarball.py
+++ b/showyourwork/cli/commands/tarball.py
@@ -1,18 +1,19 @@
-import os
-import subprocess
-
 from ... import paths
+from .run_snakemake import run_snakemake
 
 
-def tarball(options=""):
+def tarball(snakemake_args=[], cores=1, conda_frontend="conda"):
     """Build the article tarball.
 
     Args:
         options (str, optional): Additional options to pass to Snakemake.
     """
     snakefile = paths.showyourwork().workflow / "build.smk"
-    snakemake = f"SNAKEMAKE_OUTPUT_CACHE=\"{paths.user().cache}\" SNAKEMAKE_RUN_TYPE='tarball' snakemake -c1 --use-conda --conda-frontend conda --reason --cache"
-    command = f'{snakemake} {options} -s "{snakefile}" syw__arxiv_entrypoint'
-    result = subprocess.run(command, shell=True, check=False)
-    if result.returncode > 0:
-        os._exit(1)
+    run_snakemake(
+        snakefile.as_posix(),
+        run_type="tarball",
+        cores=cores,
+        conda_frontend=conda_frontend,
+        extra_args=list(snakemake_args) + ["syw__arxiv_entrypoint"],
+        check=True,
+    )

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -84,12 +84,31 @@ def main():
         ignore_unknown_options=True,
     )
 )
+@click.option(
+    "-c",
+    "--cores",
+    default="1",
+    help="Number of cores to use; passed to snakemake.",
+)
+@click.option(
+    "--conda-frontend",
+    default="conda",
+    help="The conda frontend to use; passed to snakemake.",
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
-def build(snakemake_args):
+def build(cores, conda_frontend, snakemake_args):
     """Build an article in the current working directory."""
     ensure_top_level()
-    commands.preprocess()
-    commands.build(snakemake_args)
+    commands.preprocess(
+        snakemake_args=snakemake_args,
+        cores=cores,
+        conda_frontend=conda_frontend,
+    )
+    commands.build(
+        snakemake_args=snakemake_args,
+        cores=cores,
+        conda_frontend=conda_frontend,
+    )
 
 
 def validate_slug(context, param, slug):
@@ -246,7 +265,22 @@ def setup(slug, yes, quiet, cache, overleaf, ssh, action_spec):
     commands.setup(slug, cache, overleaf, ssh, action_spec)
 
 
-@main.command()
+@main.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+    )
+)
+@click.option(
+    "-c",
+    "--cores",
+    default="1",
+    help="Number of cores to use; passed to snakemake.",
+)
+@click.option(
+    "--conda-frontend",
+    default="conda",
+    help="The conda frontend to use; passed to snakemake.",
+)
 @click.option(
     "-f",
     "--force",
@@ -259,18 +293,49 @@ def setup(slug, yes, quiet, cache, overleaf, ssh, action_spec):
     is_flag=True,
     help="Forcefully remove the `.snakemake` and `~/.showyourwork` directories.",
 )
-def clean(force, deep):
+@click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
+def clean(cores, conda_frontend, force, deep, snakemake_args):
     """Clean the article build in the current working directory."""
     ensure_top_level()
-    commands.clean(force, deep)
+    commands.clean(
+        force,
+        deep,
+        snakemake_args=snakemake_args,
+        cores=cores,
+        conda_frontend=conda_frontend,
+    )
 
 
-@main.command()
-def tarball():
+@main.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+    )
+)
+@click.option(
+    "-c",
+    "--cores",
+    default="1",
+    help="Number of cores to use; passed to snakemake.",
+)
+@click.option(
+    "--conda-frontend",
+    default="conda",
+    help="The conda frontend to use; passed to snakemake.",
+)
+@click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
+def tarball(cores, conda_frontend, snakemake_args):
     """Generate a tarball of the build in the current working directory."""
     ensure_top_level()
-    commands.preprocess()
-    commands.tarball()
+    commands.preprocess(
+        snakemake_args=snakemake_args,
+        cores=cores,
+        conda_frontend=conda_frontend,
+    )
+    commands.tarball(
+        snakemake_args=snakemake_args,
+        cores=cores,
+        conda_frontend=conda_frontend,
+    )
 
 
 @main.group()


### PR DESCRIPTION
This PR consolidates all the logic for actually executing `snakemake` as a subprocess, and in the meantime exposes the `--cores` and `--conda-frontend` arguments that were previously hard-coded (`1` and `"conda"`, respectively).

The only potentially problematic change I see here is that now all the extra `snakemake` arguments (the ones that aren't recognized by `showyourwork`) are passed to the `preprocess` command as well as `build`. I think this is the right behavior, but if anyone thinks of a reason why not, let me know!