### PR TITLE
Add a reminder to clear cache when static figures are updated

### DIFF
--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -300,8 +300,8 @@ This directory is meant to house figure files that can't be generated from
 scripts, such as photos, flowcharts, reproductions of figures in other papers, etc.
 If you place your figure in here, |showyourwork| will know not to try to
 generate it from any script.
-When a static figure is being updated, the respective caches in the github 
-workflow should be deleted to ensure that the build considers the new figure. 
+When a static figure is being updated, the respective caches in the github
+workflow should be deleted to ensure that the build considers the new figure.
 
 
 .. _tex:

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -300,6 +300,8 @@ This directory is meant to house figure files that can't be generated from
 scripts, such as photos, flowcharts, reproductions of figures in other papers, etc.
 If you place your figure in here, |showyourwork| will know not to try to
 generate it from any script.
+When a static figure is being updated, the respective caches in the github 
+workflow should be deleted to ensure that the build considers the new figure. 
 
 
 .. _tex:


### PR DESCRIPTION
When a static figure is changed, the showyourwork build on github does not take the update into account right away because it uses a cached version. This can lead to the situation where an old figure ends up in the PDF even though the updated version is in the `src/static/` directory.

I suggest to add a line in the docs to spare inexperienced users like myself the troubleshooting.