### PR TITLE
Fixing #278 by adding explicit dependencies on static figures

### DIFF
--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -328,6 +328,7 @@ def get_json_tree():
 
         # Get the figure \script, if it exists
         scripts = figure.findall("SCRIPT")
+        extra_dependencies = []
         if len(scripts) and scripts[0].text is not None:
 
             # The user provided an argument to \script{}, which we assume
@@ -366,18 +367,17 @@ def get_json_tree():
             # If all the figures in this environment exist in the
             # static directory, set up the command to copy them over
             if static:
-                srcs = " ".join(
-                    [
-                        str(
-                            (
-                                paths.user().static / Path(graphic).name
-                            ).relative_to(paths.user().repo)
+                srcs = [
+                    str(
+                        (paths.user().static / Path(graphic).name).relative_to(
+                            paths.user().repo
                         )
-                        for graphic in graphics
-                    ]
-                )
+                    )
+                    for graphic in graphics
+                ]
+                extra_dependencies = srcs
                 dest = paths.user().figures.relative_to(paths.user().repo)
-                command = f"cp {srcs} {dest}"
+                command = f"cp {' '.join(srcs)} {dest}"
 
             else:
 
@@ -386,7 +386,9 @@ def get_json_tree():
                 command = None
 
         # Collect user-defined dependencies
-        dependencies = config["dependencies"].get(script, [])
+        dependencies = (
+            list(config["dependencies"].get(script, [])) + extra_dependencies
+        )
 
         # Same, but recursing all the way up the graph
         # (i.e., including dependendencies of dependencies, and so forth)
@@ -467,23 +469,21 @@ def get_json_tree():
 
     # Add entries to the tree: static figures
     # (copy them over from the static folder)
-    srcs = " ".join(
-        [
-            str(
-                (paths.user().static / Path(graphic).name).relative_to(
-                    paths.user().repo
-                )
+    srcs = [
+        str(
+            (paths.user().static / Path(graphic).name).relative_to(
+                paths.user().repo
             )
-            for graphic in free_floating_static
-        ]
-    )
+        )
+        for graphic in free_floating_static
+    ]
     dest = paths.user().figures.relative_to(paths.user().repo)
     figures["free-floating-static"] = {
         "script": None,
         "graphics": free_floating_static,
-        "datasets": [],
+        "datasets": srcs,
         "dependencies": [],
-        "command": f"cp {srcs} {dest}",
+        "command": f"cp {' '.join(srcs)} {dest}",
         "static": True,
     }
 

--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -481,8 +481,8 @@ def get_json_tree():
     figures["free-floating-static"] = {
         "script": None,
         "graphics": free_floating_static,
-        "datasets": srcs,
-        "dependencies": [],
+        "datasets": [],
+        "dependencies": srcs,
         "command": f"cp {' '.join(srcs)} {dest}",
         "static": True,
     }

--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -482,7 +482,7 @@ def get_json_tree():
         "script": None,
         "graphics": free_floating_static,
         "datasets": [],
-        "dependencies": srcs,
+        "dependencies": [],
         "command": f"cp {' '.join(srcs)} {dest}",
         "static": True,
     }

--- a/showyourwork/workflow/scripts/preprocess.py
+++ b/showyourwork/workflow/scripts/preprocess.py
@@ -386,9 +386,10 @@ def get_json_tree():
                 command = None
 
         # Collect user-defined dependencies
-        dependencies = (
-            list(config["dependencies"].get(script, [])) + extra_dependencies
-        )
+        dependencies = config["dependencies"].get(script, [])
+        if isinstance(dependencies, str):
+            dependencies = [dependencies]
+        dependencies += list(extra_dependencies)
 
         # Same, but recursing all the way up the graph
         # (i.e., including dependendencies of dependencies, and so forth)
@@ -482,7 +483,7 @@ def get_json_tree():
         "script": None,
         "graphics": free_floating_static,
         "datasets": [],
-        "dependencies": [],
+        "dependencies": srcs,
         "command": f"cp {' '.join(srcs)} {dest}",
         "static": True,
     }


### PR DESCRIPTION
@matiscke — This should fix the issue you were seeing in #278. The basic problem is that we weren't explicitly tracking the figure in the `static` directory as a dependency of the generated figure in `figures`. This meant that when determining whether or not to update the copy `showyourwork` wouldn't take into account the modification time of the  static figure. This was also an issue locally, not just on GitHub Actions, and I've confirmed that this fix does the trick for me!