### PR TITLE
Remove rogue space after `\variable`

### DIFF
--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -210,5 +210,5 @@
 
 % Alias of \input for syw-controlled files
 \newcommand\variable[1]{%
-  \input{#1}\label{#1}\unskip%
+  \input{#1}\unskip\label{#1}\unskip%
 }


### PR DESCRIPTION
Just a small commit that will remove the space after the use of `\variable` and therefore close #286. 

This is the before:
![Screenshot 2023-02-16 at 09 30 03](https://user-images.githubusercontent.com/15774281/219309943-b9399ae6-4224-4a03-a2d1-2af912f1798d.png)

And the after:
![Screenshot 2023-02-16 at 09 30 18](https://user-images.githubusercontent.com/15774281/219310002-42662d7f-b730-4a24-a926-fbf890ebaa54.png)
