### PR TITLE
Add note about ancient() and ignoring timestamps

### DIFF
--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -534,3 +534,15 @@ isn't an issue unless users don't have the correct credentials to access an Over
 in which case the ``git clone`` silently fails and no ``master`` branch is created.
 If you run into this error, delete or comment out the ``overleaf:`` section of the ``environment.yml``
 workflow config and re-run the workflow, or simply upgrade |showyourwork|.
+
+
+Using existing (data) files by ignoring timestamps
+--------------------------------------------------
+
+When starting up a project or when in a rapid development phase, it can be useful to
+tell ``Snakemake`` to ignore changes to a file or timestamp when running the build. For
+example, you may have a slow rule to generate a data file from querying an external data
+archive and you just want to use a temporary subset of the data or existing copy of the
+data. ``Snakemake`` supports this with the ``ancient()`` command. See the `Snakemake
+documentation
+<https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ignoring-timestamps>`_ for more information about how to use this in a rule.

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -534,4 +534,3 @@ isn't an issue unless users don't have the correct credentials to access an Over
 in which case the ``git clone`` silently fails and no ``master`` branch is created.
 If you run into this error, delete or comment out the ``overleaf:`` section of the ``environment.yml``
 workflow config and re-run the workflow, or simply upgrade |showyourwork|.
-

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -535,14 +535,3 @@ in which case the ``git clone`` silently fails and no ``master`` branch is creat
 If you run into this error, delete or comment out the ``overleaf:`` section of the ``environment.yml``
 workflow config and re-run the workflow, or simply upgrade |showyourwork|.
 
-
-Using existing (data) files by ignoring timestamps
---------------------------------------------------
-
-When starting up a project or when in a rapid development phase, it can be useful to
-tell ``Snakemake`` to ignore changes to a file or timestamp when running the build. For
-example, you may have a slow rule to generate a data file from querying an external data
-archive and you just want to use a temporary subset of the data or existing copy of the
-data. ``Snakemake`` supports this with the ``ancient()`` command. See the `Snakemake
-documentation
-<https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ignoring-timestamps>`_ for more information about how to use this in a rule.

--- a/docs/snakefile.rst
+++ b/docs/snakefile.rst
@@ -199,3 +199,15 @@ all user rules). This means that if there are two rules that can generate the
 same output, Snakemake will always favor the user-defined rule.
 You can take advantage of this to provide custom rules to build individual
 figures or even the article PDF itself.
+
+Using existing (data) files in a workflow by ignoring timestamps
+----------------------------------------------------------------
+
+When starting up a project or when in a rapid development phase, it can be useful to
+tell Snakemake to ignore changes to a file or timestamp when running the build. For
+example, you may have a slow rule to generate a data file from querying an external data
+archive and you just want to use a temporary subset of the data or existing copy of the
+data. Snakemake supports this with the ``ancient()`` command. See the `Snakemake
+documentation
+<https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ignoring-timestamps>`_
+for more information about how to use this in a rule.


### PR DESCRIPTION
I think eventually this should be discussed more in the "draft" mode documentation, but for now I wanted to just make a note about this *somewhere*.