### PR TITLE
Enable and document monochrome and custom color margin icons

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -522,7 +522,7 @@ Finally, dependencies of the manuscript file are also allowed:
 
 **Type:** ``bool``
 
-**Description:** Makes all margin_icons black, this will override and custom colors.
+**Description:** Makes all margin_icons black, this will override any custom colors.
 
 **Required:** no
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -441,6 +441,96 @@ Finally, dependencies of the manuscript file are also allowed:
     src/tex/ms.tex:
         - src/tex/stylesheet.tex
 
+.. _config.margin_icons:
+
+``margin_icons``
+^^^^^^^^^^^^^^^^
+
+**Type:** ``mapping``
+
+**Description:** Define the color of the margin icons. 
+
+**Required:** no
+
+**Example:** 
+
+.. code-block:: yaml
+
+    margin_icons: 
+        custom:
+            dataset: "0.5,0.2,0.6"
+
+.. _config.margin_icons.colors:
+
+``margin_icons.colors``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``mapping``
+
+**Description:** Allows custom colors to be set for the margin icons. 
+
+**Required:** no
+
+.. _config.margin_icons.colors.cache: 
+
+``margin_icons.colors.cache``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A string describing the desired rgb values for colour the Zenodo cache margin icon. 
+
+**Required:** no
+
+.. _config.margin_icons.colors.dataset: 
+
+``margin_icons.colors.dataset``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A string describing the desired rgb values for colour the Zenodo dataset margin icon. 
+
+**Required:** no
+
+.. _config.margin_icons.colors.github: 
+
+``margin_icons.colors.github``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A string describing the desired rgb values for colour the github margin icon. 
+
+**Required:** no
+
+.. _config.margin_icons.colors.sandbox: 
+
+``margin_icons.colors.sandbox``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A string describing the desired rgb values for colour the Zenodo Sandbox cache margin icon. 
+
+**Required:** no
+
+.. _config.margin_icons.monochrome: 
+
+``margin_icons.monochrome``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``bool``
+
+**Description:** Makes all margin_icons black, this will override and custom colors. 
+
+**Required:** no
+
+.. code-block:: yaml
+
+    margin_icons: 
+        monochrome: false
+
 
 .. _config.ms:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -448,15 +448,15 @@ Finally, dependencies of the manuscript file are also allowed:
 
 **Type:** ``mapping``
 
-**Description:** Define the color of the margin icons. 
+**Description:** Define the color of the margin icons.
 
 **Required:** no
 
-**Example:** 
+**Example:**
 
 .. code-block:: yaml
 
-    margin_icons: 
+    margin_icons:
         custom:
             dataset: "0.5,0.2,0.6"
 
@@ -467,68 +467,68 @@ Finally, dependencies of the manuscript file are also allowed:
 
 **Type:** ``mapping``
 
-**Description:** Allows custom colors to be set for the margin icons. 
+**Description:** Allows custom colors to be set for the margin icons.
 
 **Required:** no
 
-.. _config.margin_icons.colors.cache: 
+.. _config.margin_icons.colors.cache:
 
 ``margin_icons.colors.cache``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``str``
 
-**Description:** A string describing the desired rgb values for colour the Zenodo cache margin icon. 
+**Description:** A string describing the desired rgb values for colour the Zenodo cache margin icon.
 
 **Required:** no
 
-.. _config.margin_icons.colors.dataset: 
+.. _config.margin_icons.colors.dataset:
 
 ``margin_icons.colors.dataset``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``str``
 
-**Description:** A string describing the desired rgb values for colour the Zenodo dataset margin icon. 
+**Description:** A string describing the desired rgb values for colour the Zenodo dataset margin icon.
 
 **Required:** no
 
-.. _config.margin_icons.colors.github: 
+.. _config.margin_icons.colors.github:
 
 ``margin_icons.colors.github``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``str``
 
-**Description:** A string describing the desired rgb values for colour the github margin icon. 
+**Description:** A string describing the desired rgb values for colour the github margin icon.
 
 **Required:** no
 
-.. _config.margin_icons.colors.sandbox: 
+.. _config.margin_icons.colors.sandbox:
 
 ``margin_icons.colors.sandbox``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``str``
 
-**Description:** A string describing the desired rgb values for colour the Zenodo Sandbox cache margin icon. 
+**Description:** A string describing the desired rgb values for colour the Zenodo Sandbox cache margin icon.
 
 **Required:** no
 
-.. _config.margin_icons.monochrome: 
+.. _config.margin_icons.monochrome:
 
 ``margin_icons.monochrome``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Type:** ``bool``
 
-**Description:** Makes all margin_icons black, this will override and custom colors. 
+**Description:** Makes all margin_icons black, this will override and custom colors.
 
 **Required:** no
 
 .. code-block:: yaml
 
-    margin_icons: 
+    margin_icons:
         monochrome: false
 
 

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -338,6 +338,18 @@ def parse_config():
             "maxlen", 40
         )
 
+        #: Showyourwork margin_icon settings
+        config["margin_icons"] = as_dict(config.get("margin_icons", {}))
+        config["margin_icons"]["colors"] = as_dict(config["margin_icons"].get("colors", {}))
+        config["margin_icons"]["monochrome"] = config["margin_icons"].get("monochrome", False)
+        config["margin_icons"]["colors"]["github"] = config["margin_icons"]["colors"].get("github", "0.12,0.47,0.71")
+        config["margin_icons"]["colors"]["sandbox"] = config["margin_icons"]["colors"].get("sandbox", "0.80,0.14,0.19")
+        config["margin_icons"]["colors"]["cache"] = config["margin_icons"]["colors"].get("cache", "0.12,0.47,0.71")
+        config["margin_icons"]["colors"]["dataset"] = config["margin_icons"]["colors"].get("dataset", "0.12,0.47,0.71")
+        print(config["margin_icons"]["colors"])
+
+
+
         #
         # -- Internal settings --
         #

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -340,13 +340,24 @@ def parse_config():
 
         #: Showyourwork margin_icon settings
         config["margin_icons"] = as_dict(config.get("margin_icons", {}))
-        config["margin_icons"]["colors"] = as_dict(config["margin_icons"].get("colors", {}))
-        config["margin_icons"]["monochrome"] = config["margin_icons"].get("monochrome", False)
-        config["margin_icons"]["colors"]["github"] = config["margin_icons"]["colors"].get("github", "0.12,0.47,0.71")
-        config["margin_icons"]["colors"]["sandbox"] = config["margin_icons"]["colors"].get("sandbox", "0.80,0.14,0.19")
-        config["margin_icons"]["colors"]["cache"] = config["margin_icons"]["colors"].get("cache", "0.12,0.47,0.71")
-        config["margin_icons"]["colors"]["dataset"] = config["margin_icons"]["colors"].get("dataset", "0.12,0.47,0.71")
-
+        config["margin_icons"]["colors"] = as_dict(
+            config["margin_icons"].get("colors", {})
+        )
+        config["margin_icons"]["monochrome"] = config["margin_icons"].get(
+            "monochrome", False
+        )
+        config["margin_icons"]["colors"]["github"] = config["margin_icons"][
+            "colors"
+        ].get("github", "0.12,0.47,0.71")
+        config["margin_icons"]["colors"]["sandbox"] = config["margin_icons"][
+            "colors"
+        ].get("sandbox", "0.80,0.14,0.19")
+        config["margin_icons"]["colors"]["cache"] = config["margin_icons"][
+            "colors"
+        ].get("cache", "0.12,0.47,0.71")
+        config["margin_icons"]["colors"]["dataset"] = config["margin_icons"][
+            "colors"
+        ].get("dataset", "0.12,0.47,0.71")
 
         #
         # -- Internal settings --

--- a/showyourwork/config.py
+++ b/showyourwork/config.py
@@ -346,8 +346,6 @@ def parse_config():
         config["margin_icons"]["colors"]["sandbox"] = config["margin_icons"]["colors"].get("sandbox", "0.80,0.14,0.19")
         config["margin_icons"]["colors"]["cache"] = config["margin_icons"]["colors"].get("cache", "0.12,0.47,0.71")
         config["margin_icons"]["colors"]["dataset"] = config["margin_icons"]["colors"].get("dataset", "0.12,0.47,0.71")
-        print(config["margin_icons"]["colors"])
-
 
 
         #

--- a/showyourwork/workflow/resources/styles/build.tex
+++ b/showyourwork/workflow/resources/styles/build.tex
@@ -55,14 +55,9 @@
   \smash{\raisebox{-1.4ex}{\includegraphics[width=7.3em]{showyourwork-logo.pdf}}}\xspace%
 }
 
-% Define custom colors
-\definecolor{sywRed}{rgb}{0.80,0.14,0.19}
+% Define custom stamp colors
 \definecolor{sywStampRed}{rgb}{0.80,0.45,0.45}
 \definecolor{sywStampLightRed}{rgb}{0.90,0.74,0.74}
-\definecolor{sywOrange}{rgb}{1.0,0.65,0.0}
-\definecolor{sywYellow}{rgb}{1.0,0.88,0.30}
-\definecolor{sywBlue}{rgb}{0.12,0.47,0.71}
-\definecolor{sywGreen}{rgb}{0.13,0.53,0.23}
 
 % Generate the stamp on the first page
 \ifAddStamp
@@ -132,7 +127,7 @@
 \newcommand\syw@Script[1]{%
   \raisebox{0pt}[6pt][0pt]{%
     \href{\syw@url/blob/\syw@sha/\usevalue{#1}}{%
-      \color{sywBlue}\faGithub%
+      \color{github-icon}\faGithub%
     }%
   }%
 }
@@ -141,7 +136,7 @@
 \newcommand\syw@DatasetOne[1]{%
   \raisebox{0pt}[6pt][6pt]{%
     \href{\usevalue{#1}}{%
-      \color{sywBlue}\faDatabase%
+      \color{dataset-icon}\faDatabase%
     }%
   }%
 }
@@ -150,7 +145,7 @@
 \newcommand\syw@DatasetTwo[1]{%
   \raisebox{0pt}[6pt][6pt]{%
     \href{\usevalue{#1}}{%
-      \color{sywBlue}\faDatabase%
+      \color{dataset-icon}\faDatabase%
     }%
   }%
 }
@@ -159,7 +154,7 @@
 \newcommand\syw@DatasetThree[1]{%
   \raisebox{0pt}[6pt][6pt]{%
     \href{\usevalue{#1}}{%
-      \color{sywBlue}\faDatabase%
+      \color{dataset-icon}\faDatabase%
     }%
   }%
 }
@@ -169,11 +164,11 @@
   \raisebox{0pt}[6pt][6pt]{%
     \IfSubStr*{\usevalue{#1}}{sandbox}{%
       \href{\usevalue{#1}}{%
-        \color{sywRed}\faRecycle%
+        \color{sandbox-icon}\faRecycle%
       }%
     }{%
       \href{\usevalue{#1}}{%
-        \color{sywBlue}\faRecycle%
+        \color{cache-icon}\faRecycle%
       }%
     }%
   }%
@@ -183,7 +178,7 @@
 \newcommand\syw@Variable[1]{%
   \raisebox{0pt}[6pt][0pt]{%
     \href{\syw@url/blob/\syw@sha/\usevalue{#1}}{%
-      \color{sywBlue}\faGithub%
+      \color{github-icon}\faGithub%
     }%
   }%
 }

--- a/showyourwork/workflow/scripts/compile_setup.py
+++ b/showyourwork/workflow/scripts/compile_setup.py
@@ -19,7 +19,6 @@ if __name__ == "__main__":
 
     # Copy over the source files
     shutil.copytree(paths.user().tex, compile_dir, dirs_exist_ok=True)
-
     if snakemake.params.metadata:
         # Metadata file jinja template
         TEMPLATE = r"""
@@ -44,6 +43,17 @@ if __name__ == "__main__":
         \newcommand{\syw@stampAngle}{((- stamp.angle -))}
         \newcommand{\syw@stampText}{((- stamp.text -))}
         \newcommand{\syw@stampVersion}{((- stamp.version -))}
+
+        ((* if margin_icons.monochrome *))
+        \definecolor{github-icon}{rgb}{0.0,0.0,0.0}
+        \definecolor{sandbox-icon}{rgb}{0.0,0.0,0.0}
+        \definecolor{cache-icon}{rgb}{0.0,0.0,0.0}
+        \definecolor{dataset-icon}{rgb}{0.0,0.0,0.0}
+        ((* else *))
+        ((* for key, value in margin_icons.colors.items() *))
+        \definecolor{((- key -))-icon}{rgb}{((- value -))}
+        ((* endfor *))
+        ((* endif *))
 
         ((* for key, value in labels.items() *))
         \addvalue{((- key -))}{((- value -))}

--- a/showyourwork/workflow/scripts/compile_setup.py
+++ b/showyourwork/workflow/scripts/compile_setup.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
 
     # Copy over the source files
     shutil.copytree(paths.user().tex, compile_dir, dirs_exist_ok=True)
+
     if snakemake.params.metadata:
         # Metadata file jinja template
         TEMPLATE = r"""


### PR DESCRIPTION
This PR will close #290. 

It allows the margin icons to be forced to be monochrome, with the boolean `margin_icons.monochrome` (this will override custom colours). 

If the users would like custom colours these can be set as rgb strings for `margin_icons.colors.github` (or `sandbox`/`dataset`/`cache`). 

The decision to have `monochrome` the level above has two benefits: 
- Less yaml for the user
- Cleaner implementation of the loop in [compile_setup.py](https://github.com/showyourwork/showyourwork/compare/main...arm61:issue-290?expand=1#diff-aef33a3097c39d53a3da97ac621516421407a54b08b0a9fb6410111a32980828)