### PR TITLE
doc: `showyourwork build` now required instead of `showyourwork`

### DIFF
--- a/docs/quickbuild.rst
+++ b/docs/quickbuild.rst
@@ -29,7 +29,7 @@
 
       .. code-block:: bash
 
-         showyourwork
+         showyourwork build
 
       .. raw:: html
 


### PR DESCRIPTION
I think `build` is no longer the default action for the `showyourwork` command. Just updating the docs to reflect this.