### PR TITLE
Fix regex for overleaf setup

### DIFF
--- a/showyourwork/overleaf.py
+++ b/showyourwork/overleaf.py
@@ -11,7 +11,7 @@ from .subproc import get_stdout
 OVERLEAF_BLANK_PROJECT_REGEX_TEMPLATE = r"[\n\r\s]+".join(
     [
         r"\\documentclass{article}",
-        r"\\usepackage\[utf8\]{inputenc}",
+        r"(\\usepackage{graphicx} % Required for inserting images)|(\\usepackage\[utf8\]{inputenc})",
         r"\\title{[^\n{}]+?}",
         r"\\author{[^\n{}]+?}",
         r"\\date{[^\n{}]+?}",


### PR DESCRIPTION
Fixes #322 

Verified the regex with regexr.com- I wasn't sure whether to include the full comment in the regex or not. Should be backwards-compatible.

I tested setting up a new project locally with the integration and it worked fine, completely fixing the bug reported in the issue.

<details>
<summary>text output</summary>

```
Creating a draft deposit on Zenodo Sandbox...
Created draft with concept DOI 10.5072/zenodo.1169527 on Zenodo Sandbox.
Fetching Overleaf repo...
Setting up Overleaf repo...
```
</details>