### PR TITLE
Update VSCode defaults with preferred build command

### DIFF
--- a/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.vscode/settings.json
+++ b/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "latex-workshop.latex.external.build.command": "showyourwork",
-    "latex-workshop.latex.external.build.args": [],
+    "latex-workshop.latex.external.build.args": ["build"],
     "latex-workshop.view.pdf.viewer": "tab",
     "latex-workshop.latex.outDir": "%WORKSPACE_FOLDER%"
 }


### PR DESCRIPTION
`showyourwork` was deprecated in favor of `showyourwork build`. This updates the default VSCode settings.