### PR TITLE
Allow user-defined tectonic.yml

### DIFF
--- a/showyourwork/workflow/rules/compile.smk
+++ b/showyourwork/workflow/rules/compile.smk
@@ -7,6 +7,11 @@ Runs the script :doc:`pdf` to generate the article ``ms.pdf``.
 from pathlib import Path
 from showyourwork import paths
 
+# Allow user to define their own tectonic.yml file in their repo:
+tectonic_yml = paths.user().repo / "tectonic.yml"
+if not tectonic_yml.exists():
+    tectonic_yml = paths.showyourwork().envs / "tectonic.yml"
+
 rule:
     """
     Setup the temporary files for compilation.
@@ -54,7 +59,7 @@ rule:
         (paths.user().compile / f'{config["ms_name"]}.pdf').as_posix(),
         (paths.user().compile / f'{config["ms_name"]}.synctex.gz').as_posix(),
     conda:
-        (paths.showyourwork().envs / "tectonic.yml").as_posix()
+        tectonic_yml.as_posix()
     shell:
         """
         cd "{input.compile_dir}"

--- a/showyourwork/workflow/rules/preprocess.smk
+++ b/showyourwork/workflow/rules/preprocess.smk
@@ -9,6 +9,11 @@ file containing metadata about the build and the workflow graph.
 from showyourwork import paths
 
 
+# Allow user to define their own tectonic.yml file in their repo:
+tectonic_yml = paths.user().repo / "tectonic.yml"
+if not tectonic_yml.exists():
+    tectonic_yml = paths.showyourwork().envs / "tectonic.yml"
+
 rule:
     """
     Setup the temporary files for compilation.
@@ -47,7 +52,7 @@ rule:
     output:
         (paths.user().preprocess / "showyourwork.xml").as_posix()
     conda:
-        (paths.showyourwork().envs / "tectonic.yml").as_posix()
+        tectonic_yml.as_posix()
     shell:
         """
         cd "{input.compile_dir}"


### PR DESCRIPTION
This is a really simple change that checks the user's repository for a `tectonic.yml` file. If not found, it falls back to the repository version.

This is useful if you need to use a different teconic version, or, in my case, if you need an extra graphics library/fontspec/etc for your compilation (since the build environment is completely isolated).

In my case I needed the `pygments` library which is used by the LaTeX package `minted` - something I can't do outside of the LaTeX process - so it needs to be added to the tectonic env. So, I simply created a custom `tectonic.yml` and added this `pygments` library to it, and now everything works.

---

@dfm sorry for the spam but do you think you could review and merge?

I can add docs on this later, I just need to get this working quickly so my paper coming out later today actually compiles without hacks, since it's a nice demo of what SYW can do :P