### PR TITLE
Create HTML export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ junit
 dist/*
 .vscode
 build
+html

--- a/showyourwork/cli/commands/__init__.py
+++ b/showyourwork/cli/commands/__init__.py
@@ -5,6 +5,7 @@ Implements all the subcommands of the ``showyourwork`` command line tool.
 from .build import build
 from .cache import cache_restore, cache_update
 from .clean import clean
+from .html import html
 from .preprocess import preprocess
 from .setup import setup
 from .tarball import tarball

--- a/showyourwork/cli/commands/html.py
+++ b/showyourwork/cli/commands/html.py
@@ -1,0 +1,19 @@
+from ... import paths
+from .run_snakemake import run_snakemake
+
+
+def html(snakemake_args=[], cores=1, conda_frontend="conda"):
+    """Build the html.
+
+    Args:
+        options (str, optional): Additional options to pass to Snakemake.
+    """
+    snakefile = paths.showyourwork().workflow / "build.smk"
+    run_snakemake(
+        snakefile.as_posix(),
+        run_type="html",
+        cores=cores,
+        conda_frontend=conda_frontend,
+        extra_args=list(snakemake_args) + ["syw__ar5ivist_entrypoint"],
+        check=True,
+    )

--- a/showyourwork/cli/main.py
+++ b/showyourwork/cli/main.py
@@ -10,7 +10,7 @@ import click
 from .. import __version__, exceptions, git
 from . import commands
 
-SUBCOMMANDS = ["build", "cache", "clean", "setup", "tarball"]
+SUBCOMMANDS = ["build", "cache", "clean", "setup", "tarball", "html"]
 OPTIONS = ["-v", "--version", "--help"]
 
 
@@ -348,6 +348,27 @@ def tarball(cores, conda_frontend, project, snakemake_args):
             conda_frontend=conda_frontend,
         )
         commands.tarball(
+            snakemake_args=snakemake_args,
+            cores=cores,
+            conda_frontend=conda_frontend,
+        )
+
+
+@main_command
+@click.option(*cores_option.args, **cores_option.kwargs)
+@click.option(*conda_frontend_option.args, **conda_frontend_option.kwargs)
+@click.option(*project_option.args, **project_option.kwargs)
+@click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
+def html(cores, conda_frontend, project, snakemake_args):
+    """Generate a HTML version of the build in the current working directory."""
+    with cwd_as(project):
+        ensure_top_level()
+        commands.preprocess(
+            snakemake_args=snakemake_args,
+            cores=cores,
+            conda_frontend=conda_frontend,
+        )
+        commands.html(
             snakemake_args=snakemake_args,
             cores=cores,
             conda_frontend=conda_frontend,

--- a/showyourwork/paths.py
+++ b/showyourwork/paths.py
@@ -61,6 +61,8 @@ class user:
         self.preprocess.mkdir(exist_ok=True)
         self.compile = self.temp / "compile"
         self.compile.mkdir(exist_ok=True)
+        self.html = self.temp / "html"
+        self.html.mkdir(exist_ok=True)
         self.logs = self.temp / "logs"
         self.logs.mkdir(exist_ok=True)
         self.zenodo = self.temp / "zenodo"

--- a/showyourwork/paths.py
+++ b/showyourwork/paths.py
@@ -50,6 +50,8 @@ class user:
         self.static = self.src / "static"
         self.figures = self.tex / "figures"
         self.output = self.tex / "output"
+        self.html = self.repo / "html"
+        self.html.mkdir(exist_ok=True)
 
         # Temporary paths
         self.temp = self.repo / ".showyourwork"
@@ -61,8 +63,8 @@ class user:
         self.preprocess.mkdir(exist_ok=True)
         self.compile = self.temp / "compile"
         self.compile.mkdir(exist_ok=True)
-        self.html = self.temp / "html"
-        self.html.mkdir(exist_ok=True)
+        self.compile_html = self.temp / "html"
+        self.compile_html.mkdir(exist_ok=True)
         self.logs = self.temp / "logs"
         self.logs.mkdir(exist_ok=True)
         self.zenodo = self.temp / "zenodo"

--- a/showyourwork/workflow/build.smk
+++ b/showyourwork/workflow/build.smk
@@ -58,11 +58,14 @@ if (paths.user().temp / "config.json").exists():
 
     rule syw__ar5ivist_entrypoint:
         input:
-            paths.user().html / "index.html"
+            (paths.user().compile_html / "index.html").as_posix()
         output:
-            "html/index.html"
+            (paths.user().html / "index.html").as_posix()
+        params:
+            compile_dir=paths.user().compile_html.as_posix(),
+            output_dir=paths.user().html.as_posix()
         shell:
-            "cp {input} {output}"
+            "cp -r {params.compile_dir} {params.output_dir}"
 
 
     # Include all other rules

--- a/showyourwork/workflow/build.smk
+++ b/showyourwork/workflow/build.smk
@@ -56,6 +56,14 @@ if (paths.user().temp / "config.json").exists():
         input:
             "arxiv.tar.gz"
 
+    rule syw__ar5ivist_entrypoint:
+        input:
+            paths.user().html / "index.html"
+        output:
+            "html/index.html"
+        shell:
+            "cp {input} {output}"
+
 
     # Include all other rules
     include: "rules/common.smk"
@@ -64,10 +72,12 @@ if (paths.user().temp / "config.json").exists():
     include: "rules/compile.smk"
     include: "rules/zenodo.smk"
     include: "rules/figure.smk"
+    include: "rules/ar5ivist.smk"
     include: "rules/render_dag.smk"
 
     # Resolve ambiguities in rule order
     ruleorder: syw__compile > syw__arxiv
+    ruleorder: syw__compile > syw__ar5ivist
 
 
     # Include custom rules defined by the user

--- a/showyourwork/workflow/rules/ar5ivist.smk
+++ b/showyourwork/workflow/rules/ar5ivist.smk
@@ -17,12 +17,16 @@ rule:
         temporary_tex_files(),
         compile_dir=paths.user().compile.as_posix()
     output:
-        paths.user().html / "index.html",
+        (paths.user().compile_html / "index.html").as_posix(),
+    params:
+        html_dir=paths.user().compile_html.as_posix(),
     shell:
         """
+        set -e
         cd {input.compile_dir}
+        mkdir -p syw_html
         docker run -v "$(pwd)":/docdir -w /docdir \
                     --user "$(id -u):$(id -g)" \
-                    latexml/ar5ivist:2301.01 --source=ms.tex --destination=tmphtml/index.html
-        mv tmphtml/* {output}/
+                    latexml/ar5ivist:2301.01 --source=ms.tex --destination=syw_html/index.html
+        mv syw_html {params.html_dir}
         """

--- a/showyourwork/workflow/rules/ar5ivist.smk
+++ b/showyourwork/workflow/rules/ar5ivist.smk
@@ -1,0 +1,28 @@
+"""
+Defines the rule ``syw__ar5ivist``.
+
+Runs ar5ivist to generate an HTML version of the manuscript.
+
+"""
+rule:
+    """
+    Generate a tarball for arXiv submission.
+
+    """
+    name:
+        "syw__ar5ivist"
+    message:
+        "Generating the arXiv tarball..."
+    input:
+        temporary_tex_files(),
+        compile_dir=paths.user().compile.as_posix()
+    output:
+        paths.user().html / "index.html",
+    shell:
+        """
+        cd {input.compile_dir}
+        docker run -v "$(pwd)":/docdir -w /docdir \
+                    --user "$(id -u):$(id -g)" \
+                    latexml/ar5ivist:2301.01 --source=ms.tex --destination=tmphtml/index.html
+        mv tmphtml/* {output}/
+        """


### PR DESCRIPTION
This creates a new command:

```
showyourwork html
```

which uses LaTeXML to convert the manuscript to an HTML version. It uses @dginev's https://github.com/dginev/ar5ivist which is a good set of defaults and css files (same settings used in ar5iv.org).

In particular it uses the `ar5ivist` docker image, so if a user wants to use this, they need to have docker setup. There's currently no conda-forge implementation of latexml, so this is the only option.

I could also create a GitHub action for this if it's of interest. In theory you could have a GitHub pages be generated for any SYW paper hosted on GitHub.

@dfm wdyt? I know you are interested in mystjs as well so I'll just point out that this would not rule out mystjs integration; they could definitely be integrated in some way. This is just a LaTeX -> HTML converter that works on the exact same input files.

---

This would likely be better suited as a plugin or a `.contrib` but I found it really difficult to get it working this way due to the "spooky action at a distance" import structure in the `.smk` files. This seems like the only option for right now. Maybe we can refactor things later so that plugins/user-defined postprocessing is possible.

---

Fixes #321