### PR TITLE
Fix bug in `showyourwork clean --deep`

### DIFF
--- a/showyourwork/cli/commands/clean.py
+++ b/showyourwork/cli/commands/clean.py
@@ -39,5 +39,3 @@ def clean(force, deep, snakemake_args=[], cores=1, conda_frontend="conda"):
     if deep:
         if (paths.user().repo / ".snakemake").exists():
             shutil.rmtree(paths.user().repo / ".snakemake")
-        if paths.user().home_temp.exists():
-            shutil.rmtree(paths.user().home_temp)


### PR DESCRIPTION
Fixes #353 

This just removes the conditional that was causing the issue, but I'm not sure if it needs to be replaced by something else? In particular, I don't see where `'.showyourwork'` is being cleaned up.