### PR TITLE
Recommend the user use `shell-escape-cwd`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1057,12 +1057,14 @@ in the compiled PDF.
 
 .. code-block:: yaml
 
-  tectonic_args: ["-Z", "shell-escape"]
+  tectonic_args: ["-Z", "shell-escape", "-Z", "shell-escape-cwd=."]
 
 to enable TeX shell escape functionality (allows the script to run
 arbitrary commands within TeX; be careful as this could be a security hazard).
 This is required to use the ``minted`` package for syntax highlighting of code
-snippets.
+snippets. The `shell-escape-cwd=.` option lets `showyourwork` save outputs
+of shell calls, whereas without this option they would be deleted (for example,
+the `minted` cache).
 
 .. _config.verbose:
 


### PR DESCRIPTION
This adds another recommended tectonic arg to the docs. This arg is required to use packages such as `minted` and `biber`.

Otherwise, because `tectonic` builds in a temporary directory, all intermediate outputs and caches will be deleted and therefore not recorded in the arxiv tarball.

With this change and #364 I was finally able to get a working arxiv tarball that uses the `minted` package!

(For any people who find this - the repo https://github.com/MilesCranmer/pysr_paper is a working example of `showyourwork` + `minted`, without needing to do any tweaks to the arxiv tarball.)