### PR TITLE
Switch to using micromamba on CI instead of setup-miniconda

### DIFF
--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -15,17 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.8" # almost oldest Python supported by PSF
-          - "3.10" # newest Python that is stable
+          - "3.8"
+          - "3.10"
         platform:
           - ubuntu-latest
-          - macos-latest
-          # - windows-latest
-        exclude:
+        include:
           - platform: macos-latest
-            python: "3.8"
-          # - platform: windows-latest
-          #   python: "3.8"
+            python: "3.9"
     runs-on: ${{ matrix.platform }}
     name: Run local integration tests
     steps:

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -38,6 +38,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python }}
             mamba
+            tectonic=0.12.0
 
       - name: Install showyourwork
         shell: bash -l {0}

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Set up Python and mamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          environment-name: test-env
           create-args: >-
             python=${{ matrix.python }}
             mamba

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -35,17 +35,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Clean up homebrew on mac
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew reinstall icu4c
-          brew cleanup
-
-      - name: Set up python
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python and mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python }}
+          create-args: >-
+            python=${{ matrix.python }}
+            mamba
 
       - name: Install showyourwork
         shell: bash -l {0}

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -34,11 +34,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set up python
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python and mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          python-version: "3.9"
+          create-args: >-
+            python=3.9
+            mamba
 
       - name: Install showyourwork
         shell: bash -l {0}

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up Python and mamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          environment-name: test-env
           create-args: >-
             python=3.9
             mamba

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up Python and mamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          environment-name: test-env
           create-args: >-
             python=${{ matrix.python }}
             mamba

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
           # - windows-latest
         exclude:
           - platform: macos-latest
-            python: "3.9"
+            python: "3.8"
           # - platform: windows-latest
           #   python: "3.8"
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,15 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.8" # (almost) oldest Python supported by PSF
-          - "3.10" # newest Python that is stable
+          - "3.8"
+          - "3.11"
         platform:
           - ubuntu-latest
           - macos-latest
           # - windows-latest
         exclude:
           - platform: macos-latest
-            python: "3.8"
+            python: "3.9"
           # - platform: windows-latest
           #   python: "3.8"
     runs-on: ${{ matrix.platform }}
@@ -34,11 +34,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set up python
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python and mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python }}
+          create-args: >-
+            python=${{ matrix.python }}
+            mamba
 
       - name: Install showyourwork
         shell: bash -l {0}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,16 +15,12 @@ jobs:
       matrix:
         python:
           - "3.8"
-          - "3.11"
+          - "3.10"
         platform:
           - ubuntu-latest
-          # - macos-latest
-          # - windows-latest
         include:
           - platform: macos-latest
             python: "3.9"
-          # - platform: windows-latest
-          #   python: "3.8"
     runs-on: ${{ matrix.platform }}
     name: Run unit tests
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,11 +18,11 @@ jobs:
           - "3.11"
         platform:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
           # - windows-latest
-        exclude:
+        include:
           - platform: macos-latest
-            python: "3.8"
+            python: "3.9"
           # - platform: windows-latest
           #   python: "3.8"
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
This should speed up CI builds and (I think!) fix the macos failures.