### PR TITLE
add Schlecker et al. 2023

### DIFF
--- a/docs/projects.json
+++ b/docs/projects.json
@@ -157,8 +157,8 @@
       "Arnaud Salvador",
       "Kevin K. Hardegree-Ullman"
     ],
-    "doi": "",
-    "url": "https://github.com/matiscke/hz-inner-edge-discontinuity",
+    "doi": "arXiv:2309.04518",
+    "url": "https://arxiv.org/abs/2309.04518",
     "field": "Astronomy"
       },
 }

--- a/docs/projects.json
+++ b/docs/projects.json
@@ -146,5 +146,19 @@
     "doi": "arXiv:2305.18244",
     "url": "https://arxiv.org/abs/arXiv:2305.18244",
     "field": "Materials Science"
-  }
+  },
+    "matiscke/hz-inner-edge-discontinuity": {
+    "title": "Bioverse: The Habitable Zone Inner Edge Discontinuity as an Imprint of Runaway Greenhouse Climates on Exoplanet Demographics",
+    "authors": [
+      "Martin Schlecker",
+      "Dániel Apai",
+      "Tim Lichtenberg",
+      "Galen Bergsten",
+      "Arnaud Salvador",
+      "Kevin K. Hardegree-Ullman"
+    ],
+    "doi": "",
+    "url": "https://github.com/matiscke/hz-inner-edge-discontinuity",
+    "field": "Astronomy"
+      },
 }


### PR DESCRIPTION
this adds Schlecker et al. 2023, accepted in PSJ, to the list of papers that use showyourwork. 