### PR TITLE
Fixing installation spec for remote tests

### DIFF
--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 1
       matrix:
         showyourwork-spec:
-          - ${{ (github.event_name == 'push' && format('git+https://github.com/showyourwork/showyourwork.git@{0}#egg=showyourwork', github.sha)) || format('git+{0}@{1}#egg=showyourwork', github.event.pull_request.head.repo.clone_url, github.event.pull_request.head.sha) }}
+          - ${{ (github.event_name == 'push' && format('git+https://github.com/showyourwork/showyourwork.git@{0}', github.sha)) || format('git+{0}@{1}', github.event.pull_request.head.repo.clone_url, github.event.pull_request.head.sha) }}
     steps:
       - name: Remove `safe to test` label
         if: ${{ (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test')) }}
@@ -46,11 +46,11 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -U pip
-          python -m pip install -e "${{ matrix.showyourwork-spec }}[tests]"
+          python -m pip install -e 'showyourwork[tests] @ ${{ matrix.showyourwork-spec }}'
 
       - name: Run remote integration tests
         shell: bash -l {0}
-        run: python -m pytest --remote -m "remote" tests/integration --action-spec ${{ matrix.showyourwork-spec }}
+        run: python -m pytest --remote -m "remote" tests/integration --action-spec "${{ matrix.showyourwork-spec }}#egg=showyourwork"
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
           OVERLEAF_EMAIL: ${{ secrets.OVERLEAF_EMAIL }}


### PR DESCRIPTION
This was broken in #396 because previously SYW was installed as editable in `src`, which caused a collision.