### PR TITLE
Update Overleaf Credential

### DIFF
--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -53,6 +53,5 @@ jobs:
         run: python -m pytest --remote -m "remote" tests/integration --action-spec "${{ matrix.showyourwork-spec }}#egg=showyourwork"
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
-          OVERLEAF_EMAIL: ${{ secrets.OVERLEAF_EMAIL }}
-          OVERLEAF_PASSWORD: ${{ secrets.OVERLEAF_PASSWORD }}
+          OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
           GH_API_KEY: ${{ secrets.GH_API_KEY }}

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -218,7 +218,7 @@ you'll get the following message:
     </pre>
 
 To allow |showyourwork| to push to/pull from your Overleaf project, create
-the environment variable ``$OVERLEAF_TOKEN`` and populate them with your 
+the environment variable ``$OVERLEAF_TOKEN`` and populate them with your
 Overleaf token; then re-run the setup command. You can create a new Overleaf
 token by visiting your `account settings <https://www.overleaf.com/user/settings>`_.
 Again, take care to never actually commit this information to your repository!

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -208,19 +208,19 @@ you'll get the following message:
     <pre>
     You provided an Overleaf project id, so I'm going to set up Overleaf integration
     for this repository. Please make sure at this time that you have defined the
-    <span class="text-highlight">OVERLEAF_EMAIL</span> and <span class="text-highlight">OVERLEAF_PASSWORD</span> environment variables. In order for this to
+    <span class="text-highlight">OVERLEAF_TOKEN</span> environment variable. In order for this to
     work on GitHub Actions, please go to
 
         <span class="text-highlight">https://github.com/tmp/tmp/settings/secrets/actions/new</span>
 
-    at this time and create <span class="text-highlight">OVERLEAF_EMAIL</span> and <span class="text-highlight">OVERLEAF_PASSWORD</span> secrets with your
-    Overleaf credentials.
+    at this time and create <span class="text-highlight">OVERLEAF_TOKEN</span> secret with your
+    Overleaf token.
     </pre>
 
 To allow |showyourwork| to push to/pull from your Overleaf project, create
-the environment variables ``$OVERLEAF_EMAIL`` and ``$OVERLEAF_PASSWORD`` and
-populate them with your Overleaf email address and password, respectively;
-then re-run the setup command.
+the environment variable ``$OVERLEAF_TOKEN`` and populate them with your 
+Overleaf token; then re-run the setup command. You can create a new Overleaf
+token by visiting your `account settings <https://www.overleaf.com/user/settings>`_.
 Again, take care to never actually commit this information to your repository!
 
 

--- a/docs/overleaf.rst
+++ b/docs/overleaf.rst
@@ -67,9 +67,9 @@ a moment. On your project page, you should see a single file called ``main.tex``
 containing some minimal TeX stuff. Don't edit anything in it, as it will get
 overwritten momentarily by |showyourwork|.
 
-Next, on your machine, define the environment variable ``$OVERLEAF_TOKEN`` 
+Next, on your machine, define the environment variable ``$OVERLEAF_TOKEN``
 with your Overleaf token. To generate a new token from Overleaf,
-go to your `account settings <https://www.overleaf.com/user/settings>`__ and 
+go to your `account settings <https://www.overleaf.com/user/settings>`__ and
 add a new token under the ``Git Integration`` section. As with the other
 credentials required by |showyourwork|, you'll also need to create corresponding
 GitHub Actions secrets at the following URL

--- a/docs/overleaf.rst
+++ b/docs/overleaf.rst
@@ -67,12 +67,11 @@ a moment. On your project page, you should see a single file called ``main.tex``
 containing some minimal TeX stuff. Don't edit anything in it, as it will get
 overwritten momentarily by |showyourwork|.
 
-Next, on your machine, define the environment variables ``$OVERLEAF_EMAIL``
-and ``$OVERLEAF_PASSWORD`` with your Overleaf credentials. Unfortunately,
-Overleaf does not yet support token-based authentication, so the only way
-to grant |showyourwork| access to your project is by providing the email
-and password for your Overleaf account. As with the other credentials required
-by |showyourwork|, you'll also need to create corresponding
+Next, on your machine, define the environment variable ``$OVERLEAF_TOKEN`` 
+with your Overleaf token. To generate a new token from Overleaf,
+go to your `account settings <https://www.overleaf.com/user/settings>`__ and 
+add a new token under the ``Git Integration`` section. As with the other
+credentials required by |showyourwork|, you'll also need to create corresponding
 GitHub Actions secrets at the following URL
 
 .. code-block:: text

--- a/src/showyourwork/cli/main.py
+++ b/src/showyourwork/cli/main.py
@@ -230,12 +230,12 @@ def validate_slug(context, param, slug):
                     f"""
                     You provided an Overleaf project id, so I'm going to set up
                     Overleaf integration for this repository. Please make sure
-                    at this time that you have defined the `OVERLEAF_EMAIL` and
-                    `OVERLEAF_PASSWORD` environment variables. In order for
+                    at this time that you have defined the `OVERLEAF_TOKEN`
+                    environment variable. In order for
                     this to work on GitHub Actions, please go to
                     ``https://github.com/{slug}/settings/secrets/actions/new``
-                    at this time and create `OVERLEAF_EMAIL` and
-                    `OVERLEAF_PASSWORD` secrets with your Overleaf credentials.
+                    at this time and create `OVERLEAF_TOKEN` secret with
+                    your Overleaf token.
                     """
                 )
             pause()
@@ -276,7 +276,7 @@ def validate_slug(context, param, slug):
     "--overleaf",
     help="Overleaf project id to sync with (optional). Requires Overleaf "
     "credentials, provided as the environment variables and GitHub repository "
-    "secrets `OVERLEAF_EMAIL` and `OVERLEAF_PASSWORD`.",
+    "secrets `OVERLEAF_TOKEN`.",
     default=None,
     type=type("PROJECT_ID", (str,), {}),
 )

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
@@ -22,5 +22,4 @@ jobs:
           showyourwork-spec: {{ cookiecutter.action_spec }}{% endif %}
         env:
           SANDBOX_TOKEN: ${{ "{{" }} secrets.SANDBOX_TOKEN {{ "}}" }}
-          OVERLEAF_EMAIL: ${{ "{{" }} secrets.OVERLEAF_EMAIL {{ "}}" }}
-          OVERLEAF_PASSWORD: ${{ "{{" }} secrets.OVERLEAF_PASSWORD {{ "}}" }}
+          OVERLEAF_TOKEN: ${{ "{{" }} secrets.OVERLEAF_TOKEN {{ "}}" }}

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
@@ -22,5 +22,4 @@ jobs:
           showyourwork-spec: {{ cookiecutter.action_spec }}{% endif %}
         env:
           SANDBOX_TOKEN: ${{ "{{" }} secrets.SANDBOX_TOKEN {{ "}}" }}
-          OVERLEAF_EMAIL: ${{ "{{" }} secrets.OVERLEAF_EMAIL {{ "}}" }}
-          OVERLEAF_PASSWORD: ${{ "{{" }} secrets.OVERLEAF_PASSWORD {{ "}}" }}
+          OVERLEAF_TOKEN: ${{ "{{" }} secrets.OVERLEAF_TOKEN {{ "}}" }}

--- a/src/showyourwork/exceptions/overleaf.py
+++ b/src/showyourwork/exceptions/overleaf.py
@@ -23,10 +23,9 @@ class OverleafRateLimitExceeded(OverleafException):
 class MissingOverleafCredentials(OverleafException):
     def __init__(self, **kwargs):
         message = (
-            "Overleaf credentials `OVERLEAF_EMAIL` and/or "
-            "`OVERLEAF_PASSWORD` not found. "
-            "These should be set as both environment variables "
-            "and GitHub repository secrets."
+            "Overleaf credential `OVERLEAF_TOKEN` not found. "
+            "This should be set as both environment variable "
+            "and GitHub repository secret."
         )
         super().__init__(
             message,

--- a/src/showyourwork/overleaf.py
+++ b/src/showyourwork/overleaf.py
@@ -159,10 +159,7 @@ def wipe_remote(project_id, tex=None):
         get_stdout(["git", "init"], cwd=cwd)
         get_stdout(["git", "checkout", "-b", "master"], cwd=cwd)
         overleaf_token = get_overleaf_credentials()
-        url = (
-            f"https://git:{overleaf_token}"
-            f"@git.overleaf.com/{project_id}"
-        )
+        url = f"https://git:{overleaf_token}" f"@git.overleaf.com/{project_id}"
         get_stdout(
             ["git", "pull", url],
             cwd=cwd,

--- a/src/showyourwork/overleaf.py
+++ b/src/showyourwork/overleaf.py
@@ -57,37 +57,31 @@ def check_for_rate_limit(code, stdout, stderr):
 
 
 def get_overleaf_credentials(
-    overleaf_email="OVERLEAF_EMAIL",
-    overleaf_password="OVERLEAF_PASSWORD",
+    overleaf_token="OVERLEAF_TOKEN",
     error_if_missing=False,
 ):
     """
-    Return the user's Overleaf email and password, stored in env vars.
+    Return the user's Overleaf token, stored in env vars.
 
     Args:
-        overleaf_email (str, optional): Environment variable containing the
-            Overleaf account email address. Default ``OVERLEAF_EMAIL``.
-        overleaf_password (str, optional): Environment variable containing the
-            Overleaf account password. Default ``OVERLEAF_PASSWORD``.
+        overleaf_token (str, optional): Environment variable containing the
+            Overleaf account password. Default ``OVERLEAF_TOKEN``.
         error_if_missing (bool, optional): Default ``False``.
 
     """
-    creds = []
-    for key in [overleaf_email, overleaf_password]:
-        val = os.getenv(key, None)
-        if val is None or not len(val):
-            if error_if_missing:
-                level = "error"
-            else:
-                # This exception is caught in the enclosing scope
-                level = "warn"
-            raise exceptions.MissingOverleafCredentials(level=level)
+    val = os.getenv(overleaf_token, None)
+    if val is None or not len(val):
+        if error_if_missing:
+            level = "error"
         else:
-            # Replace special characters in the credentials
-            val = quote(val, safe="")
-            creds.append(val)
+            # This exception is caught in the enclosing scope
+            level = "warn"
+        raise exceptions.MissingOverleafCredentials(level=level)
+    else:
+        # Replace special characters in the credentials
+        val = quote(val, safe="")
 
-    return creds
+    return val
 
 
 def clone(project_id, path=None):
@@ -115,8 +109,8 @@ def clone(project_id, path=None):
     paths.user(path=path).overleaf.mkdir(exist_ok=True)
 
     # Get the credentials & repo url
-    overleaf_email, overleaf_password = get_overleaf_credentials()
-    url = f"https://{overleaf_email}:{overleaf_password}@git.overleaf.com/{project_id}"
+    overleaf_token = get_overleaf_credentials()
+    url = f"https://git:{overleaf_token}@git.overleaf.com/{project_id}"
 
     # Set up a local version of the repo. We don't actually _clone_ it to avoid
     # storing the url containing the password in .git/config
@@ -144,7 +138,7 @@ def clone(project_id, path=None):
     get_stdout(
         ["git", "pull", url],
         cwd=str(paths.user(path=path).overleaf),
-        secrets=[overleaf_email, overleaf_password],
+        secrets=[overleaf_token],
         callback=callback,
     )
 
@@ -164,18 +158,15 @@ def wipe_remote(project_id, tex=None):
     with TemporaryDirectory() as cwd:
         get_stdout(["git", "init"], cwd=cwd)
         get_stdout(["git", "checkout", "-b", "master"], cwd=cwd)
-        (
-            overleaf_email,
-            overleaf_password,
-        ) = get_overleaf_credentials()
+        overleaf_token = get_overleaf_credentials()
         url = (
-            f"https://{overleaf_email}:{overleaf_password}"
+            f"https://git:{overleaf_token}"
             f"@git.overleaf.com/{project_id}"
         )
         get_stdout(
             ["git", "pull", url],
             cwd=cwd,
-            secrets=[overleaf_email, overleaf_password],
+            secrets=[overleaf_token],
         )
         get_stdout(["git", "rm", "-r", "*"], cwd=cwd)
         with open(Path(cwd) / "main.tex", "w") as f:
@@ -196,7 +187,7 @@ def wipe_remote(project_id, tex=None):
                 get_stdout(
                     ["git", "push", url, "master"],
                     cwd=cwd,
-                    secrets=[overleaf_email, overleaf_password],
+                    secrets=[overleaf_token],
                     callback=check_for_rate_limit,
                 )
 
@@ -312,12 +303,12 @@ def setup_remote(project_id, path=None):
     )
 
     # Push (again being careful about secrets)
-    overleaf_email, overleaf_password = get_overleaf_credentials()
-    url = f"https://{overleaf_email}:{overleaf_password}@git.overleaf.com/{project_id}"
+    overleaf_token = get_overleaf_credentials()
+    url = f"https://git:{overleaf_token}@git.overleaf.com/{project_id}"
     get_stdout(
         ["git", "push", url, "master"],
         cwd=str(paths.user(path=path).overleaf),
-        secrets=[overleaf_email, overleaf_password],
+        secrets=[overleaf_token],
         callback=check_for_rate_limit,
     )
 
@@ -422,12 +413,12 @@ def push_files(files, project_id, path=None):
     )
 
     # Push (again being careful about secrets)
-    overleaf_email, overleaf_password = get_overleaf_credentials()
-    url = f"https://{overleaf_email}:{overleaf_password}@git.overleaf.com/{project_id}"
+    overleaf_token = get_overleaf_credentials()
+    url = f"https://git:{overleaf_token}@git.overleaf.com/{project_id}"
     get_stdout(
         ["git", "push", url, "master"],
         cwd=str(paths.user(path=path).overleaf),
-        secrets=[overleaf_email, overleaf_password],
+        secrets=[overleaf_token],
         callback=check_for_rate_limit,
     )
 


### PR DESCRIPTION
Overleaf stopped support for git clone with email address and password. It requires accessing with token. This PR will close #465. Changes in docs are needed later on.