### PR TITLE
Add Known Issues page to the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-latest"
 
 conda:
   environment: docs/environment.yml

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -11,6 +11,10 @@ Finally, always make sure you are using the latest version of |showyourwork|, as
 your error could be due to a bug we have since fixed! You can always upgrade to
 the latest version by running ``pip install -U showyourwork``.
 
+As a last resort before opening an issue on the GitHub repository,
+please take a look to the :ref:`known_issues` for a list of issues known by the developers,
+but which have not yet been fixed in a stable release.
+
 
 Debugging local builds
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ Contents
    logging
    migrating
    reproducibility
+   known_issues
    faqs
    contributorguide
    api/showyourwork

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,3 +23,6 @@ You can also install the latest development version from GitHub:
     Check out the latest release on
     `PyPI <https://pypi.python.org/pypi/showyourwork>`__ and read the release
     notes at :doc:`changelog`.
+
+    See :ref:`known_issues` for a list of issues known by the developers,
+    but which have not yet been fixed in a stable release.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,0 +1,34 @@
+.. _known_issues:
+
+Known issues
+============
+
+This page collects issues that are known by the developers but they
+are not yet fixed in the latest release.
+
+Each entry reports also the original issue tracker from GitHub.
+
+`Build on github is broken with 'pulp' has no attribute 'list_solvers' (#435) <https://github.com/showyourwork/showyourwork/issues/435>`_
+-----------------------------------------------------------------------------------------------------------------------------------------
+
+When using *showyourwork!*, along with the local version you installed on your computer
+another one will be installed by GitHub for its server-side action
+in order to compile the final document when you push your changes to the upstream repository.
+
+If you see this error in your workflow logs you need to change what version of *showyourwork!*
+is installed on the GitHub side.
+This  can be directly done by editing the ``.github/workflows/build.yml`` file saved
+in your local *showyourwork!* article directory.
+
+For example, if you want GitHub to install and use the latest development version of *showyourwork!*,
+then look for the following lines in the ``build.yml`` and ``build-pull-request.yml`` workflow files
+and modify the ``Build the article PDF`` step like this,
+
+.. code-block:: yaml
+
+    - name: Build the article PDF
+      id: build
+      with:
+        showyourwork-spec: git+https://github.com/showyourwork/showyourwork
+      uses: showyourwork/showyourwork-action@v1
+    

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -31,4 +31,3 @@ and modify the ``Build the article PDF`` step like this,
       with:
         showyourwork-spec: git+https://github.com/showyourwork/showyourwork
       uses: showyourwork/showyourwork-action@v1
-    


### PR DESCRIPTION
This PR adds a new page to the documentation where we can list issues that are known by the developers or part of the users, but which fix didn't yet make it to a stable release.

I took the liberty to start filling it already with issue #435 which I continuously hit and forget.