### PR TITLE
Make sure the documentation can be built locally

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+
 import hacks
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
The `hacks` module cannot be found by `sphinx-build` when calling `make html` from the docs directory unless it is visible from the import namespace.

This can be done both by using `sys.path` or `importlib`; since I had no particular preference I went for the easier approach.