### PR TITLE
Set write permissions to all jobs triggered by action

### DIFF
--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build the article PDF
+    permissions: write-all
     concurrency: showyourwork-${{ "{{" }} github.ref {{ "}}" }}
     steps:
       - name: Checkout

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build the article PDF
+    permissions: write-all
     concurrency: showyourwork-${{ "{{" }} github.ref {{ "}}" }}
     steps:
       - name: Checkout

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/process-pull-request.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/process-pull-request.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   process-pr:
     runs-on: ubuntu-latest
+    permissions: write-all
     name: Process pull request
     steps:
       - name: Process pull request


### PR DESCRIPTION
@dfm could you crosscheck if this is what is needed to make sure that a new project has already the correct permissions?

I still have to test it myself.

If this works, eventually we can update the documentation by removing the [corresponding entry from the FAQ](https://show-your.work/en/latest/faqs/#permissions-errors-in-github-actions).

Closes #318 
