### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-sphinx:
-  configuration: docs/conf.py
-
 build:
   os: ubuntu-20.04
   tools:
@@ -17,4 +14,5 @@ python:
       path: .
 
 sphinx:
+  configuration: docs/conf.py
   builder: dirhtml


### PR DESCRIPTION
Fix configuration file to make build succeed

I found out 2 things:

- https://github.com/rodluger/showyourwork (which is what ReadThedocs looks for and is currently failing) points to https://github.com/showyourwork/showyourwork
- these changes on my fork succeed even in a PR

so I test here if this works and if yes I'll merge immediately and update the other open PRs