### PR TITLE
Fix issue for which use of an ORCID ID caused a crash

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -61,3 +61,14 @@ to use the latest unreleased version of the action:
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
           OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
+
+`KeyError: 'tex_files_out' (#400) <https://github.com/showyourwork/showyourwork/issues/400>`_
+-----------------------------------------------------------------------------------------------------------------------------------------
+
+This error should arise only if you are using showyourwork v0.4.3
+or if you updated your project ot that specific version.
+
+If this is your case and you do not want to update showyourwork
+to the latest development version, please comment line 405 in
+`src/showyourwork/workflow/scripts/preprocess.py` which should be
+`if graphic not in config["tex_files_out"]`.

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -401,11 +401,12 @@ def get_json_tree(xmlfile):
     ] + unlabeled_graphics
 
     # Ignore graphics that are dependencies of the texfile (such as orcid-ID.png)
-    free_floating_graphics = [
-        graphic
-        for graphic in free_floating_graphics
-        if graphic not in config["tex_files_out"]
-    ]
+    if "tex_files_out" in config:
+        free_floating_graphics = [
+            graphic
+            for graphic in free_floating_graphics
+            if graphic not in config["tex_files_out"]
+        ]
 
     # Separate into dynamic and static figures
     free_floating_static = list(

--- a/tests/test_orcid_id.py
+++ b/tests/test_orcid_id.py
@@ -1,0 +1,22 @@
+from helpers import TemporaryShowyourworkRepository
+
+
+class TestOrcidID(TemporaryShowyourworkRepository):
+    """Test a paper in which the user input its  OrcidID."""
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        """Create and edit all the necessary files for the workflow."""
+
+        # Import the variable into the tex file
+        ms = self.cwd / "src" / "tex" / "ms.tex"
+        with open(ms) as f:
+            ms_orig = f.read()
+        with open(ms, "w") as f:
+            ms_new = ms_orig.replace(
+                r"\author{@showyourwork}",
+                r"\author[0000-0000-0000-0000]{@showyourwork}",
+            )
+            print(ms_new, file=f)


### PR DESCRIPTION
This PR adds a guard against the missing `tex_files_out` key in the configuration (I guess pulled from snakemake) at preprocessing level.

Thanks to @tedjohnson12 for the suggestion (let me know if you would like to be added as a [co-author in the commit](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors), I only need an email).

Said this, I still do not know when that key should appear during the workflow and why....@dfm @rodluger 

I also added a new integration test which checks than now things work again as expected.

This problem came up first in issue #400, which is now been also added to the list of _Known Issues_ in the documentation until the next release, as it is relevant for anybody who has installed _showyourwork v0.4.3_ and for some reason does not want to use the latest development version.

Closes #464 
Closes #454 