### PR TITLE
Remove main and r channels from integration tests workflow due to new Terms of Service 

### DIFF
--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
           conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
-      
+
       - name: Set channel priority
         shell: bash -l {0}
         run: |

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -39,9 +39,18 @@ jobs:
             python=${{ matrix.python }}
             mamba
 
+      - name: Accept Anaconda Terms of Service
+        shell: bash -l {0}
+        run: |
+          conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+          conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+      
       - name: Set channel priority
         shell: bash -l {0}
-        run: conda config --set channel_priority strict
+        run: |
+          conda config --remove channels defaults || true
+          conda config --add channels conda-forge
+          conda config --set channel_priority strict
 
       - name: Install showyourwork
         shell: bash -l {0}

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/environment.yml
@@ -1,6 +1,7 @@
+channels:
+  - conda-forge
 dependencies:
-  - conda-forge::numpy=1.19.2
-  - conda-forge::pip=21.0.1
-  - conda-forge::python=3.9
-  - pip:
-      - matplotlib==3.4.3
+  - numpy=2.2.6
+  - pip=25.1.1
+  - python=3.10
+  - matplotlib==3.10


### PR DESCRIPTION
As #544 shows, the CI is currently failing due to a change upstream related to new Terms of Service for channels we should not even use.

I am following the suggestion from the [logs](https://github.com/showyourwork/showyourwork/actions/runs/16428264132/job/46454068824?pr=554):

> CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
>     • https://repo.anaconda.com/pkgs/main
>     • https://repo.anaconda.com/pkgs/r
> 
> To accept a channel's Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
>     ‣ conda tos accept --override-channels --channel CHANNEL
> 
> To remove channels with rejected Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
>     ‣ conda config --remove channels CHANNEL

Not sure if the workflow is the place where this is to be changed or if it's a config change for the `snakemake` call of `conda`, but let's see.