### PR TITLE
Allow to call CLI help also with -h

### DIFF
--- a/docs/changes/575.bugfix.rst
+++ b/docs/changes/575.bugfix.rst
@@ -1,0 +1,1 @@
+Now using ``-h`` also works and will not pull anymore the help from the underlying _snakemake_ executable.

--- a/src/showyourwork/cli/main.py
+++ b/src/showyourwork/cli/main.py
@@ -12,6 +12,7 @@ from . import commands
 
 SUBCOMMANDS = ["build", "cache", "clean", "setup", "tarball"]
 OPTIONS = ["-v", "--version", "--help"]
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 # Common options:
@@ -119,7 +120,7 @@ def echo(text="", **kwargs):
         click.echo(text, **kwargs)
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(
     __version__,
     "--version",


### PR DESCRIPTION
Now using `-h` also works and will not pull anymore the help from the underlying _snakemake_ executable.

Closes #516 