### PR TITLE
Update cookiecutter template versioning scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 **/__pycache__
+**/.mypy_cache
+**/.pytest_cache
+**/.ruff_cache
 **/.showyourwork
 **/.snakemake
 **/_showyourwork_version.py

--- a/docs/changes/576.bugfix.rst
+++ b/docs/changes/576.bugfix.rst
@@ -1,0 +1,4 @@
+Now ``showyourwork setup`` accepts a new option ``--action-version`` to specify the version of the GitHub Action to use in the generated workflows.
+If not provided, it defaults to the latest release or the latest dev commit if newer.
+The existing option ``--action-spec`` still allows to specify the remote version of showyourwork to use for the workflow runs,
+but if not provided now it defaults to whatever local version is used to instantiate the project and not to the latest release as before.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -11,6 +11,10 @@ Each entry reports also the original issue tracker from GitHub.
 `Build on github is broken with 'pulp' has no attribute 'list_solvers' (#435) <https://github.com/showyourwork/showyourwork/issues/435>`_
 -----------------------------------------------------------------------------------------------------------------------------------------
 
+.. important::
+
+  Fixed after v0.4.3. Please update to a later version if you can!
+
 When using *showyourwork!*, along with the local version you installed on your computer
 another one will be installed by GitHub for its server-side action
 in order to compile the final document when you push your changes to the upstream repository.
@@ -46,6 +50,10 @@ used in this case).
 `Package 'showyourwork' requires a different Python' (#505) <https://github.com/showyourwork/showyourwork/issues/505>`_
 -----------------------------------------------------------------------------------------------------------------------
 
+.. important::
+
+  Fixed after v0.4.3. Please update to a later version if you can!
+
 This is an error that arises from a change in the conda installation on the remote.
 
 The solution is to add update the version of the Github Action used by the ``build.yml`` and ``build-pull-request.yml`` workflows
@@ -65,10 +73,10 @@ to use the latest unreleased version of the action:
 `KeyError: 'tex_files_out' (#400) <https://github.com/showyourwork/showyourwork/issues/400>`_
 -----------------------------------------------------------------------------------------------------------------------------------------
 
-This error should arise only if you are using showyourwork v0.4.3
-or if you updated your project to that specific version.
+.. important::
 
-If this is your case and you do not want to update showyourwork
-to the latest development version, please comment line 405 in
+  Fixed after v0.4.3. Please update to a later version if you can!
+
+Please comment line 405 in
 `src/showyourwork/workflow/scripts/preprocess.py` which should be
 `if graphic not in config["tex_files_out"]`.

--- a/src/showyourwork/cli/commands/setup.py
+++ b/src/showyourwork/cli/commands/setup.py
@@ -2,6 +2,7 @@ import shutil
 import time
 from pathlib import Path
 
+import requests
 from cookiecutter.main import cookiecutter
 
 from ... import __version__, exceptions, overleaf, paths
@@ -10,7 +11,7 @@ from ...subproc import get_stdout
 from ...zenodo import Zenodo
 
 
-def setup(slug, cache, overleaf_id, ssh, action_spec):
+def setup(slug, cache, overleaf_id, ssh, action_spec, action_version):
     """Set up a new article repo.
 
     Args:
@@ -20,8 +21,10 @@ def setup(slug, cache, overleaf_id, ssh, action_spec):
         ssh (bool): If True, use SSH to clone the repository. Otherwise, use HTTPS.
         action_spec (str or None): Showyourwork version passed to showyourwork-action in
             `.github/workflows/*.yml`
-
+        action_version (str or None):
+            Version of the showyourwork-action to use in the workflow.
     """
+
     # Parse the slug
     user, repo = slug.split("/")
     if Path(repo).exists():
@@ -47,6 +50,192 @@ def setup(slug, cache, overleaf_id, ssh, action_spec):
 
     name = f"@{user}".replace("_", "")
 
+    # Fetch latest showyourwork-action version if not specified
+    def get_latest_action_version():
+        # Get latest release info
+        release_url = "https://api.github.com/repos/showyourwork/showyourwork-action/releases/latest"
+        main_url = (
+            "https://api.github.com/repos/showyourwork/showyourwork-action/commits/main"
+        )
+        compare_url = "https://api.github.com/repos/showyourwork/showyourwork-action/compare/{release_tag}...main"
+        try:
+            release_resp = requests.get(release_url, timeout=5)
+            if release_resp.status_code == 200:
+                release_data = release_resp.json()
+                release_tag = release_data.get("tag_name")
+                # release_sha is not needed for comparison logic
+                # Get latest commit on main
+                main_resp = requests.get(main_url, timeout=5)
+                if main_resp.status_code == 200:
+                    main_data = main_resp.json()
+                    main_sha = main_data.get("sha")
+                    # Compare release tag with main
+                    if release_tag and main_sha:
+                        # Check if main has new commits since release
+                        comp_url = compare_url.format(release_tag=release_tag)
+                        comp_resp = requests.get(comp_url, timeout=5)
+                        if comp_resp.status_code == 200:
+                            comp_data = comp_resp.json()
+                            ahead_by = comp_data.get("ahead_by", 0)
+                            if ahead_by > 0:
+                                return main_sha
+                        # If no new commits, use release tag
+                        return release_tag
+        except Exception:
+            pass
+        # Fallback: just get latest commit SHA from main
+        try:
+            main_resp = requests.get(main_url, timeout=5)
+            if main_resp.status_code == 200:
+                main_data = main_resp.json()
+                main_sha = main_data.get("sha")
+                if main_sha:
+                    return main_sha
+        except Exception:
+            pass
+        # Final fallback
+        return "v1"
+
+    if not action_version:
+        action_version = get_latest_action_version()
+
+    # Set action_spec to match local version if not provided
+    if not action_spec:
+        DEV_GIT_URL = "git+https://github.com/showyourwork/showyourwork"
+        # Check git status first to detect uncommitted changes
+        has_uncommitted_changes = False
+        try:
+            git_status = get_stdout("git status --porcelain", shell=True).strip()
+            has_uncommitted_changes = bool(git_status)
+        except Exception:
+            # If git status fails, assume no uncommitted changes
+            pass
+
+        # Use same version remotely as locally for consistency
+        local_version = __version__
+
+        # If it's a clean release version AND no uncommitted changes, use PyPI
+        if not has_uncommitted_changes and not (
+            ".dev" in local_version
+            or "+" in local_version
+            or local_version.endswith(".dirty")
+            or "rc" in local_version
+        ):
+            # Clean release version with clean working tree - use PyPI directly
+            action_spec = f"showyourwork=={local_version}"
+        else:
+            # Development version - need to determine the right git reference
+            try:
+                # Get current branch
+                current_branch = get_stdout(
+                    "git branch --show-current", shell=True
+                ).strip()
+
+                # Use git's tracking branch information to find the right remote
+                try:
+                    # Get the upstream tracking branch for current branch
+                    upstream_branch = get_stdout(
+                        "git rev-parse --abbrev-ref --symbolic-full-name @{u}",
+                        shell=True,
+                    ).strip()
+
+                    if upstream_branch and "/" in upstream_branch:
+                        # Parse remote/branch format (e.g., "upstream/fix-branch")
+                        remote_name, remote_branch = upstream_branch.split("/", 1)
+
+                        # Check for uncommitted changes (dirty working tree)
+                        try:
+                            # Check if working tree is dirty
+                            git_status = get_stdout(
+                                "git status --porcelain",
+                                shell=True,
+                            ).strip()
+
+                            has_uncommitted = bool(git_status)
+
+                            # Check for unpushed commits
+                            local_commit = get_stdout(
+                                "git rev-parse HEAD", shell=True
+                            ).strip()
+
+                            remote_commit = get_stdout(
+                                f"git rev-parse {upstream_branch}",
+                                shell=True,
+                            ).strip()
+
+                            has_unpushed = local_commit != remote_commit
+
+                            # Warn if there are any local changes not reflected remotely
+                            if has_uncommitted or has_unpushed:
+                                logger = get_logger()
+                                if has_uncommitted and has_unpushed:
+                                    logger.warning(
+                                        f"Local branch has uncommitted changes AND "
+                                        f"unpushed commits. Remote builds will use "
+                                        f"{upstream_branch} "
+                                        f"(commit {remote_commit[:8]}), "
+                                        f"which will differ from your "
+                                        f"local working state."
+                                    )
+                                elif has_uncommitted:
+                                    logger.warning(
+                                        f"Local branch has uncommitted changes. "
+                                        f"Remote builds will use {upstream_branch} "
+                                        f"(commit {remote_commit[:8]}), which may "
+                                        f"differ from your local working state."
+                                    )
+                                else:  # has_unpushed
+                                    logger.warning(
+                                        f"Local branch has unpushed commits. "
+                                        f"Remote builds will use {upstream_branch} "
+                                        f"(commit {remote_commit[:8]}), which may "
+                                        f"differ from your local code."
+                                    )
+                        except Exception:
+                            # If any git commands fail, just proceed
+                            pass
+
+                        # Get the URL of this remote
+                        remote_url = get_stdout(
+                            f"git config --get remote.{remote_name}.url",
+                            shell=True,
+                        ).strip()
+
+                        if "github.com" in remote_url:
+                            # Parse GitHub URL to get owner/repo
+                            if remote_url.startswith("git@"):
+                                repo_part = remote_url.split(":")[-1].replace(
+                                    ".git", ""
+                                )
+                            else:
+                                repo_part = remote_url.split("github.com/")[-1].replace(
+                                    ".git", ""
+                                )
+
+                            owner, repo_name = repo_part.split("/")
+                            action_spec = f"git+https://github.com/{owner}/{repo_name}@{remote_branch}"
+                        else:
+                            # Not a GitHub remote, fallback
+                            action_spec = DEV_GIT_URL
+                    else:
+                        # No tracking branch set - warn and use main
+                        logger = get_logger()
+                        logger.warning(
+                            f"Branch '{current_branch}' has no remote tracking "
+                            f"branch. Using main branch for remote builds. "
+                            f"Consider pushing your branch first with: "
+                            f"git push -u <remote> {current_branch}"
+                        )
+                        action_spec = DEV_GIT_URL
+
+                except Exception:
+                    # If git tracking fails, fallback to main
+                    action_spec = DEV_GIT_URL
+
+            except Exception:
+                # If git commands fail, fallback to official main branch
+                action_spec = DEV_GIT_URL
+
     # Create a Zenodo deposit draft for this repo
     if cache:
         deposit_sandbox = Zenodo("sandbox", slug=slug, branch="main")
@@ -68,6 +257,7 @@ def setup(slug, cache, overleaf_id, ssh, action_spec):
             "overleaf_id": overleaf_id,
             "year": time.localtime().tm_year,
             "action_spec": action_spec,
+            "action_version": action_version,
         },
         overwrite_if_exists=True,
     )

--- a/src/showyourwork/cli/main.py
+++ b/src/showyourwork/cli/main.py
@@ -295,7 +295,16 @@ def validate_slug(context, param, slug):
     default=None,
     type=type("SPEC", (str,), {}),
 )
-def setup(slug, yes, quiet, cache, overleaf, ssh, action_spec):
+@click.option(
+    "--action-version",
+    help=(
+        "Version of the showyourwork-action to use in the workflow. "
+        "If not specified, use the latest release or latest commit on main if newer."
+    ),
+    default=None,
+    type=type("ACTION_VERSION", (str,), {}),
+)
+def setup(slug, yes, quiet, cache, overleaf, ssh, action_spec, action_version):
     """
     Set up a new article repository in the current working directory.
 
@@ -303,7 +312,7 @@ def setup(slug, yes, quiet, cache, overleaf, ssh, action_spec):
     `user/repo`, where `user` is the user's GitHub handle and `repo` is the
     name of the repository (and local directory) to create.
     """
-    commands.setup(slug, cache, overleaf, ssh, action_spec)
+    commands.setup(slug, cache, overleaf, ssh, action_spec, action_version)
 
 
 @main_command

--- a/src/showyourwork/cookiecutter-showyourwork/cookiecutter.json
+++ b/src/showyourwork/cookiecutter-showyourwork/cookiecutter.json
@@ -7,6 +7,7 @@
   "overleaf_id": null,
   "year": null,
   "action_spec": null,
+  "action_version": null,
   "_copy_without_render": [
     "src/tex/aasjournal.bst",
     "src/tex/aastex631.cls",

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build the article PDF
     permissions: write-all
-    concurrency: showyourwork-${{ "{{" }} github.ref {{ "}}" }}
+    concurrency: "{% raw %}showyourwork-${{ github.ref }}{% endraw %}"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,10 +17,10 @@ jobs:
 
       - name: Build the article PDF
         id: build
-        uses: showyourwork/showyourwork-action@v1
+        uses: showyourwork/showyourwork-action@{{ cookiecutter.action_version or 'v1' }}
         {%- if cookiecutter.action_spec %}
         with:
           showyourwork-spec: {{ cookiecutter.action_spec }}{% endif %}
         env:
-          SANDBOX_TOKEN: ${{ "{{" }} secrets.SANDBOX_TOKEN {{ "}}" }}
-          OVERLEAF_TOKEN: ${{ "{{" }} secrets.OVERLEAF_TOKEN {{ "}}" }}
+          SANDBOX_TOKEN: "{% raw %}${{ secrets.SANDBOX_TOKEN }}{% endraw %}"
+          OVERLEAF_TOKEN: "{% raw %}${{ secrets.OVERLEAF_TOKEN }}{% endraw %}"

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build the article PDF
     permissions: write-all
-    concurrency: showyourwork-${{ "{{" }} github.ref {{ "}}" }}
+    concurrency: "{% raw %}showyourwork-${{ github.ref }}{% endraw %}"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,10 +17,10 @@ jobs:
 
       - name: Build the article PDF
         id: build
-        uses: showyourwork/showyourwork-action@v1
+        uses: showyourwork/showyourwork-action@{{ cookiecutter.action_version or 'v1' }}
         {%- if cookiecutter.action_spec %}
         with:
           showyourwork-spec: {{ cookiecutter.action_spec }}{% endif %}
         env:
-          SANDBOX_TOKEN: ${{ "{{" }} secrets.SANDBOX_TOKEN {{ "}}" }}
-          OVERLEAF_TOKEN: ${{ "{{" }} secrets.OVERLEAF_TOKEN {{ "}}" }}
+          SANDBOX_TOKEN: "{% raw %}${{ secrets.SANDBOX_TOKEN }}{% endraw %}"
+          OVERLEAF_TOKEN: "{% raw %}${{ secrets.OVERLEAF_TOKEN }}{% endraw %}"

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/process-pull-request.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.github/workflows/process-pull-request.yml
@@ -9,7 +9,6 @@ jobs:
   process-pr:
     runs-on: ubuntu-latest
     permissions: write-all
-    name: Process pull request
     steps:
       - name: Process pull request
-        uses: showyourwork/showyourwork-action/process-pull-request@v1
+        uses: showyourwork/showyourwork-action/process-pull-request@{{ cookiecutter.action_version or 'v1' }}

--- a/tests/unit/test_workflow_templates.py
+++ b/tests/unit/test_workflow_templates.py
@@ -1,0 +1,120 @@
+import os
+import shutil
+import tempfile
+
+import yaml
+from cookiecutter.main import cookiecutter
+
+
+def render_and_validate_workflow(
+    template_dir,
+    workflow_name,
+    context,
+    expected_action_version,
+    action_path="showyourwork/showyourwork-action",
+):
+    temp_dir = tempfile.mkdtemp()
+    try:
+        cookiecutter(
+            template_dir,
+            no_input=True,
+            extra_context=context,
+            output_dir=temp_dir,
+        )
+        repo_name = context["repo"]
+        workflow_path = os.path.join(
+            temp_dir,
+            repo_name,
+            ".github",
+            "workflows",
+            workflow_name,
+        )
+        assert os.path.exists(workflow_path), f"Workflow {workflow_name} not found!"
+        with open(workflow_path) as f:
+            workflow_yaml = yaml.safe_load(f)
+        # Check that the correct action version is injected
+        found = False
+        for job in workflow_yaml.get("jobs", {}).values():
+            for step in job.get("steps", []):
+                uses = step.get("uses", "")
+                if uses.startswith(action_path):
+                    assert uses.endswith(f"@{expected_action_version}"), (
+                        f"Expected action version @{expected_action_version} "
+                        f"in uses: {uses}"
+                    )
+                    found = True
+        assert found, (
+            f"No step found using {action_path}@{expected_action_version} "
+            f"in {workflow_name}"
+        )
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_build_workflow_valid():
+    context = {
+        "user": "testuser",
+        "repo": "testrepo",
+        "name": "Test User",
+        "showyourwork_version": "1.0.0",
+        "cache_sandbox_doi": "",
+        "overleaf_id": None,
+        "year": 2025,
+        "action_spec": None,
+        "action_version": "v1",
+    }
+    template_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../src/showyourwork/cookiecutter-showyourwork",
+        )
+    )
+    render_and_validate_workflow(template_dir, "build.yml", context, "v1")
+
+
+def test_build_pull_request_workflow_valid():
+    context = {
+        "user": "testuser",
+        "repo": "testrepo",
+        "name": "Test User",
+        "showyourwork_version": "1.0.0",
+        "cache_sandbox_doi": "",
+        "overleaf_id": None,
+        "year": 2025,
+        "action_spec": None,
+        "action_version": "v1",
+    }
+    template_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../src/showyourwork/cookiecutter-showyourwork",
+        )
+    )
+    render_and_validate_workflow(template_dir, "build-pull-request.yml", context, "v1")
+
+
+def test_process_pull_request_workflow_valid():
+    context = {
+        "user": "testuser",
+        "repo": "testrepo",
+        "name": "Test User",
+        "showyourwork_version": "1.0.0",
+        "cache_sandbox_doi": "",
+        "overleaf_id": None,
+        "year": 2025,
+        "action_spec": None,
+        "action_version": "v1",
+    }
+    template_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../src/showyourwork/cookiecutter-showyourwork",
+        )
+    )
+    render_and_validate_workflow(
+        template_dir,
+        "process-pull-request.yml",
+        context,
+        "v1",
+        action_path="showyourwork/showyourwork-action/process-pull-request",
+    )

--- a/tests/unit/test_workflow_templates.py
+++ b/tests/unit/test_workflow_templates.py
@@ -1,9 +1,12 @@
 import os
 import shutil
 import tempfile
+from unittest.mock import patch
 
 import yaml
 from cookiecutter.main import cookiecutter
+
+from showyourwork.cli.commands.setup import setup
 
 
 def render_and_validate_workflow(
@@ -51,12 +54,98 @@ def render_and_validate_workflow(
         shutil.rmtree(temp_dir)
 
 
+class BaseSetupTest:
+    """Base class for setup command tests with common functionality."""
+
+    def setup_method(self):
+        """Set up a temporary directory for each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        try:
+            self.original_cwd = os.getcwd()
+        except FileNotFoundError:
+            # If current directory doesn't exist, use the project root
+            self.original_cwd = os.path.dirname(
+                os.path.dirname(os.path.dirname(__file__))
+            )
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        os.chdir(self.original_cwd)
+        if hasattr(self, "temp_dir"):
+            shutil.rmtree(self.temp_dir)
+
+    def run_setup_with_git_mocks(self, git_responses, version="v0.4.3.dev1+test"):
+        """
+        Run setup command with mocked git responses.
+
+        Args:
+            git_responses: Dict mapping git commands to their outputs
+            version: Version string to mock
+
+        Returns:
+            Tuple of (mock_logger_instance, repo_path, workflow_content)
+        """
+        with patch("showyourwork.cli.commands.setup.requests"):
+            with patch("showyourwork.cli.commands.setup.__version__", version):
+                with patch(
+                    "showyourwork.cli.commands.setup.get_stdout"
+                ) as mock_get_stdout:
+                    with patch(
+                        "showyourwork.cli.commands.setup.get_logger"
+                    ) as mock_logger:
+
+                        def mock_git_commands(cmd, **kwargs):
+                            cmd = cmd.strip()
+                            return git_responses.get(cmd, "")
+
+                        mock_get_stdout.side_effect = mock_git_commands
+                        mock_logger_instance = mock_logger.return_value
+
+                        os.chdir(self.temp_dir)
+
+                        # Run setup command
+                        setup(
+                            slug="testuser/testrepo",
+                            cache=False,
+                            overleaf_id=None,
+                            ssh=False,
+                            action_spec=None,  # Auto-detect
+                            action_version="v1",
+                        )
+
+                        # Read generated workflow
+                        repo_path = os.path.join(self.temp_dir, "testrepo")
+                        workflow_path = os.path.join(
+                            repo_path, ".github", "workflows", "build.yml"
+                        )
+                        with open(workflow_path) as f:
+                            workflow_content = f.read()
+
+                        return mock_logger_instance, repo_path, workflow_content
+
+    def assert_warning_logged(self, mock_logger_instance, expected_text):
+        """Assert that a warning containing the expected text was logged."""
+        mock_logger_instance.warning.assert_called()
+        warning_calls = [
+            call.args[0] for call in mock_logger_instance.warning.call_args_list
+        ]
+        assert any(
+            expected_text in msg for msg in warning_calls
+        ), f"Expected warning containing '{expected_text}', got: {warning_calls}"
+
+    def assert_action_spec_in_workflow(self, workflow_content, expected_spec):
+        """Assert that the workflow contains the expected action spec."""
+        assert (
+            expected_spec in workflow_content
+        ), f"Expected '{expected_spec}' in workflow content"
+
+
 def test_build_workflow_valid():
     context = {
         "user": "testuser",
         "repo": "testrepo",
         "name": "Test User",
-        "showyourwork_version": "1.0.0",
+        "showyourwork_version": "v0.4.3",
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -77,7 +166,7 @@ def test_build_pull_request_workflow_valid():
         "user": "testuser",
         "repo": "testrepo",
         "name": "Test User",
-        "showyourwork_version": "1.0.0",
+        "showyourwork_version": "v0.4.3",
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -98,7 +187,7 @@ def test_process_pull_request_workflow_valid():
         "user": "testuser",
         "repo": "testrepo",
         "name": "Test User",
-        "showyourwork_version": "1.0.0",
+        "showyourwork_version": "v0.4.3",
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -118,3 +207,191 @@ def test_process_pull_request_workflow_valid():
         "v1",
         action_path="showyourwork/showyourwork-action/process-pull-request",
     )
+
+
+class TestSetupCommandGitScenarios(BaseSetupTest):
+    """Test setup command behavior in complex git scenarios using the base class."""
+
+    def test_clean_pypi_version(self):
+        """Test that clean release versions use PyPI spec."""
+        git_responses = {
+            "git status --porcelain": "",  # Clean working tree
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses,
+            "v0.4.3",  # Clean release version
+        )
+
+        # Should use PyPI spec for clean release + clean working tree
+        self.assert_action_spec_in_workflow(workflow_content, "showyourwork==v0.4.3")
+
+    def test_development_version_fallback(self):
+        """Test development version with git command failures falls back to main."""
+        # Empty git responses will cause all git commands to return empty strings
+        git_responses = {}
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+local"
+        )
+
+        # Should fallback to default showyourwork git URL
+        expected = "git+https://github.com/showyourwork/showyourwork"
+        self.assert_action_spec_in_workflow(workflow_content, expected)
+
+    def test_fork_with_upstream_remote(self):
+        """Test proper handling of fork with upstream remote."""
+        git_responses = {
+            "git status --porcelain": "",
+            "git branch --show-current": "my-branch",
+            "git rev-parse --abbrev-ref --symbolic-full-name @{u}": (
+                "upstream/my-branch"
+            ),
+            "git rev-parse HEAD": "abc123local",
+            "git rev-parse upstream/my-branch": "abc123local",  # Same commits
+            "git config --get remote.upstream.url": "https://github.com/upstream/showyourwork.git",
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+fork"
+        )
+
+        # Should use upstream remote URL with the branch
+        expected = "git+https://github.com/upstream/showyourwork@my-branch"
+        self.assert_action_spec_in_workflow(workflow_content, expected)
+
+    def test_explicit_git_action_spec(self):
+        """Test that setup command handles explicit git action_spec correctly."""
+        # For explicit action_spec, we bypass the git logic entirely
+        with patch("showyourwork.cli.commands.setup.requests"):
+            with patch("showyourwork.cli.commands.setup.get_stdout") as mock_get_stdout:
+                # Return empty string for all git commands
+                mock_get_stdout.return_value = ""
+
+                os.chdir(self.temp_dir)
+
+                # Run setup with explicit git action_spec (bypasses auto-detection)
+                setup(
+                    slug="testuser/testrepo",
+                    cache=False,
+                    overleaf_id=None,
+                    ssh=False,
+                    action_spec="git+https://github.com/user/showyourwork@feature",
+                    action_version="v1",
+                )
+
+                # Check that the repo was created
+                repo_path = os.path.join(self.temp_dir, "testrepo")
+                assert os.path.exists(repo_path), "Repository not created!"
+
+                # Check the generated workflow contains our explicit git spec
+                workflow_path = os.path.join(
+                    repo_path, ".github", "workflows", "build.yml"
+                )
+                assert os.path.exists(workflow_path), "build.yml not found!"
+
+                with open(workflow_path) as f:
+                    workflow_content = f.read()
+
+                # Should contain our explicit git action_spec
+                expected_spec = "git+https://github.com/user/showyourwork@feature"
+                self.assert_action_spec_in_workflow(workflow_content, expected_spec)
+
+    def test_uncommitted_changes(self):
+        """Test setup command behavior with uncommitted changes."""
+        git_responses = {
+            "git status --porcelain": "M  some_file.py\n?? another.txt",
+            "git branch --show-current": "feature-branch",
+            "git rev-parse --abbrev-ref --symbolic-full-name @{u}": (
+                "upstream/feature-branch"
+            ),
+            "git rev-parse HEAD": "abc123local",
+            "git rev-parse upstream/feature-branch": "def456remote",
+            "git config --get remote.upstream.url": (
+                "https://github.com/myuser/showyourwork.git"
+            ),
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+uncommitted"
+        )
+
+        # Verify warning was logged about uncommitted changes
+        self.assert_warning_logged(mock_logger, "uncommitted changes")
+
+        # Should use git spec pointing to remote branch
+        expected = "git+https://github.com/myuser/showyourwork@feature-branch"
+        self.assert_action_spec_in_workflow(workflow_content, expected)
+
+    def test_unpushed_commits(self):
+        """Test setup command behavior with unpushed commits."""
+        git_responses = {
+            "git status --porcelain": "",  # Clean working tree
+            "git branch --show-current": "my-feature",
+            "git rev-parse --abbrev-ref --symbolic-full-name @{u}": (
+                "origin/my-feature"
+            ),
+            "git rev-parse HEAD": "abc123newer",
+            "git rev-parse origin/my-feature": "def456older",
+            "git config --get remote.origin.url": (
+                "git@github.com:forkuser/showyourwork.git"
+            ),
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+unpushed"
+        )
+
+        # Verify warning about unpushed commits
+        self.assert_warning_logged(mock_logger, "unpushed commits")
+
+        # Check that git spec points to the remote branch
+        expected = "git+https://github.com/forkuser/showyourwork@my-feature"
+        self.assert_action_spec_in_workflow(workflow_content, expected)
+
+    def test_no_tracking_branch(self):
+        """Test setup when local branch has no remote tracking branch."""
+        git_responses = {
+            "git status --porcelain": "",
+            "git branch --show-current": "local-only-branch",
+            "git rev-parse --abbrev-ref --symbolic-full-name @{u}": "",  # No upstream
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+local"
+        )
+
+        # Verify warning about no tracking branch
+        self.assert_warning_logged(mock_logger, "no remote tracking branch")
+
+        # Should fallback to default git URL
+        expected = "git+https://github.com/showyourwork/showyourwork"
+        self.assert_action_spec_in_workflow(workflow_content, expected)
+
+    def test_both_uncommitted_and_unpushed(self):
+        """Test setup with both uncommitted changes AND unpushed commits."""
+        git_responses = {
+            "git status --porcelain": "M  modified.py\nA  added.py",
+            "git branch --show-current": "messy-branch",
+            "git rev-parse --abbrev-ref --symbolic-full-name @{u}": (
+                "upstream/messy-branch"
+            ),
+            "git rev-parse HEAD": "local123ahead",
+            "git rev-parse upstream/messy-branch": "remote456behind",
+            "git config --get remote.upstream.url": (
+                "https://github.com/upstream/showyourwork.git"
+            ),
+        }
+
+        mock_logger, repo_path, workflow_content = self.run_setup_with_git_mocks(
+            git_responses, "v0.4.3.dev1+messy"
+        )
+
+        # Verify the combined warning message
+        self.assert_warning_logged(
+            mock_logger, "uncommitted changes AND unpushed commits"
+        )
+
+        # Should still use remote git spec
+        expected = "git+https://github.com/upstream/showyourwork@messy-branch"
+        self.assert_action_spec_in_workflow(workflow_content, expected)


### PR DESCRIPTION
This is an attempt to make template versioning a bit more dynamic and robust.

This is a summary of changes:

- introduced a new flag option to `showyourwork setup` called `--action-version` which specifies the version of the GitHub action (complementary to `--action-spec` which instead specifies the version of showyourwork that the action should use - I would even change the name of the latter in "showyourwork-remote-version" to make it clearer)
- change the default behavior of `--action-spec` to use on the remote the same version of showyourwork that the user is using to create the new project
- set the default behavior of `--action-version` to check if there are new merged PR into the main version (in this case use the latest commit) and if not use the latest release (for now v1)
- add new unit tests to make sure the cookiecutter templates contain valid YAML and have the expected verions.

On top of all local and unit tests passing I also created a [test repository](https://github.com/HealthyPear/test_pr_576) for this PR in place of the remote tests that are currently out of order to check both the build workflows and build PR workflows.

While I wait for reviews I will update the docs and changelog accordingly.

Closes #507.