### PR TITLE
Prevent potential latex options clashes

### DIFF
--- a/docs/changes/580.maintenance.rst
+++ b/docs/changes/580.maintenance.rst
@@ -1,0 +1,2 @@
+If ``showyourwork`` is imported as the last package in the preamble of your manuscript,
+the potential for package option clashes should now be greatly minimized.

--- a/docs/latex.rst
+++ b/docs/latex.rst
@@ -18,7 +18,10 @@ something like this:
     % Define document class
     \documentclass[twocolumn]{aastex631}
 
-    % Import showyourwork magic
+    % Import here any package you may need
+    \usepackage{foo}
+
+    % Import showyourwork magic (last if possible)
     \usepackage{showyourwork}
 
     % Begin!

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -372,6 +372,12 @@ your manuscript:
 
     \usepackage{showyourwork}
 
+.. tip::
+
+  We suggest putting this line after the other ``\usepackage{...}`` lines in your
+  manuscript. This should avoid option clashes between packages required by
+  |showyourwork| and packages you or your document class need to use.
+
 If you peek inside, there's not much there: it's a placeholder stylesheet that
 imports all the |showyourwork| functionality from elsewhere if the article
 is built as part of the |showyourwork| workflow. If you compile your article

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/ms.tex
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/src/tex/ms.tex
@@ -1,5 +1,10 @@
 % Define document class
 \documentclass[twocolumn]{aastex631}
+
+% Add here any additional package you need
+% \usepackage{foo}
+
+% If you can, leave this package for last
 \usepackage{showyourwork}
 
 % Begin!


### PR DESCRIPTION
I modified the tex stylesheets included by the showyourwork class so they will import a package (with any option they might need) only if such a package is not previously loaded by either the manuscript base class or by the user in the preamble.

In order for this to work I updated the documentation to state that it would be better if the showyourwork package is imported last, after any other package is needed by the user, which should allow this modification to avoid any future option clash during either preprocessing or main compilation.

There is only the caveat related to packages that are used by showyourwork with some options, which for now is only one

`\RequirePackage[notref,notcite]{showkeys}`

which, according to what I explain above has been modified with 

`\@ifpackageloaded{showkeys}{}{\RequirePackage[notref,notcite]{showkeys}}`

This might be a problem if showyourwork really needs those options, but the manuscript class and/or user import `showkeys` with conflicting options. I do not know the extent of this use case, so for now I will wait for feedback while I think of a better solution for this package.

I tested this PR succesfully on the default example project, on the MNRAS template and a new template I am preparing for JCAP.

Closes #579 