### PR TITLE
Add 'documentation' news fragment type

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -25,6 +25,10 @@ showcontent = true
 name = "Maintenance"
 showcontent = true
 
+[tool.towncrier.fragment.documentation]
+name = "Documentation"
+showcontent = true
+
 [[tool.towncrier.section]]
 name = ""
 path = ""


### PR DESCRIPTION
This PR adds a new type of news fragment specifically related to updates to the documentation (maintenance was too generic).