### PR TITLE
Fix TestOverleaf::test_local

### DIFF
--- a/tests/integration/test_overleaf.py
+++ b/tests/integration/test_overleaf.py
@@ -19,7 +19,7 @@ class TestOverleaf(TemporaryShowyourworkRepository, ShowyourworkRepositoryAction
 
     # No need to test this on CI
     local_build_only = True
-    overleaf_id = "6409f16f438b5fb7c4dfa837"
+    overleaf_id = "68cd54011c99150d9045d2b6"
 
     # Overleaf rate limit error re-try settings
     auth_retries = 1


### PR DESCRIPTION
This PR fixes this remote test that was not working since quite some time.

This is the summary of changes:

- **IMPORTANT** I guess the Overleaf token associated with the account from showyourwork (or @dfm or @rodluger) expired so this was the main issue; right now this repo and this test point at a blank Overleaf project on my private account so at some point we might want to use the old account again (or if not created, make one for this organization only for testing)
- I did not know how the old test project was made, so I made a **blank**; this triggered an issue where the wipe_remote function did not find files to remove and crashed, so I added a custom callback that gracefully handles the case where there are no files to remove, preventing the error (that was saying "path specifier '*' doesn't match any files").
- that method and pull/push methods were checking for git errors using text strings in english; this is of course not maintainable as e.g. when testing on my machine this was failing because my local is in italian 😛 so I changed the code to use `git status --porcelain` (which outputs machine-readable status)

So, in summary, the test now runs successfully again with **temporary** Overleaf credentials, and the fixes should work for any user regardless of their system's language settings.

I will just rebase/force-push my changes to remove the intermediate commits I used for debugging the remote workflow and then I think we are good to go for a review.

I will not automatically close the underlying issue (#578) when merging - see the thread below why.