### PR TITLE
Add Reep et al paper to list of projects that use `showyourwork`

### DIFF
--- a/docs/projects.json
+++ b/docs/projects.json
@@ -223,5 +223,17 @@
     "doi": "10.1063/5.0260928",
     "url": "https://doi.org/10.1063/5.0260928",
     "field": "Chemical Physics"
+  },
+  "jwreep/ebtel_abundances": {
+    "title": "Modeling Time-variable Elemental Abundances in Coronal Loop Simulations",
+    "authors": [
+      "Jeffrey W. Reep",
+      "John Unverferth",
+      "Will T. Barnes",
+      "Sherry Chhabra"
+    ],
+    "doi": "10.3847/2041-8213/ad64c3",
+    "url": "https://doi.org/10.3847/2041-8213/ad64c3",
+    "field": "Astronomy"
   }
 }


### PR DESCRIPTION
This adds the paper ["Modeling Time-variable Elemental Abundances in Coronal Loop Simulations"](https://iopscience.iop.org/article/10.3847/2041-8213/ad64c3) by @jwreep et al. (including myself) to the list of projects that use `showyourwork`.