### PR TITLE
Ignore untracked files when checking for changes using Overleaf

### DIFF
--- a/docs/changes/606.bugfix.rst
+++ b/docs/changes/606.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore untracked files when checking for changes to commit to Overleaf.

--- a/src/showyourwork/overleaf.py
+++ b/src/showyourwork/overleaf.py
@@ -586,7 +586,11 @@ def pull_files(
             callback=status_callback,
         )
 
-        if status_output:
+        changes = [
+            line for line in status_output.splitlines() if not line.startswith("??")
+        ]
+
+        if changes:
             # There are changes to commit
             get_stdout(
                 [


### PR DESCRIPTION
This can make the process crash, but untracked files should not be considered as a change of course.