### PR TITLE
Disable LaTex command \resizebox during preprocessing

### DIFF
--- a/docs/changes/610.bugfix.rst
+++ b/docs/changes/610.bugfix.rst
@@ -1,0 +1,5 @@
+The ``\resizebox`` command was causing "Division by 0" errors
+during the preprocessing stage when used in conjunction with ``\includegraphics``
+becasue at that stage there is not yet a figure to resize.
+This has been fixed by redefining ``\resizebox`` to simply wrap its content in an ``\hbox``,
+effectively disabling the resizing functionality during preprocessing while preserving the document structure.

--- a/src/showyourwork/workflow/resources/styles/preprocess.tex
+++ b/src/showyourwork/workflow/resources/styles/preprocess.tex
@@ -93,6 +93,11 @@
   \syw@LogMessage{<GRAPHICS>#2</GRAPHICS>}%
 }
 
+% Disable resizebox to prevent "Division by 0" errors
+% when used with includegraphics (which doesn't produce actual content)
+% Wrap in an hbox to preserve structure without actually resizing
+\renewcommand{\resizebox}[3]{\hbox{#3}}
+
 % Log graphicspath
 \renewcommand{\graphicspath}[1]{%
   \syw@LogMessage{<GRAPHICSPATH>#1</GRAPHICSPATH>}%


### PR DESCRIPTION
Some manuscripts might have to add figures like this,

```tex
\begin{figure*}[htb!]
\centering
   \resizebox{0.42\hsize}{!}{\includegraphics{figures/foo.pdf}}
\end{figure*}
```

This is a problem during preprocessing because:

1. the manuscript uses e.g. `\resizebox{width}{!}{...}` with `\includegraphics` to auto-calculate aspect ratios
2. during preprocessing, showyourwork redefines `\includegraphics` to only log the filename without actually including the graphic
3. when `\resizebox` tries to measure the content to calculate aspect ratio (the `!` parameter), there's nothing to measure, causing `"Division by 0"`

This PR solves this by redefining this command to ignore its first two arguments and simply place its third argument inside a horizontal box.

Of course this is valid only for this step of showyourwork: once reaching the compile step a fresh copy of the manuscript is considered and by that time the figure file is where it should be.

