### PR TITLE
Make sure DAG generation rule uses same Python version as showyourwork

### DIFF
--- a/docs/changes/617.bugfix.rst
+++ b/docs/changes/617.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug for which the DAG generation enabled via the
+``dag/render`` option in ``showyourwork.yml``
+would crash with a pickle-related error.

--- a/src/showyourwork/workflow/envs/render_dag.yml
+++ b/src/showyourwork/workflow/envs/render_dag.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
-  - imagemagick=7.1.0.43
-  - python-graphviz=0.20.1
+  - python
+  - imagemagick
+  - python-graphviz

--- a/tests/integration/test_dag.py
+++ b/tests/integration/test_dag.py
@@ -1,0 +1,30 @@
+from helpers import TemporaryShowyourworkRepository
+
+
+class TestDagGeneration(TemporaryShowyourworkRepository):
+    """Ensure a local build produces `dag.pdf`."""
+
+    # Keep this local only; remote covered elsewhere
+    local_build_only = True
+
+    def customize(self):
+        """Enable DAG rendering in the source config."""
+        config_file = self.cwd / "showyourwork.yml"
+        with open(config_file) as f:
+            lines = f.readlines()
+
+        # Find and replace the render: false line in the dag section
+        new_lines = []
+        for line in lines:
+            if "render: false" in line and new_lines and "dag" in new_lines[-1]:
+                new_lines.append(line.replace("render: false", "render: true"))
+            else:
+                new_lines.append(line)
+
+        with open(config_file, "w") as f:
+            f.writelines(new_lines)
+
+    def check_build(self):
+        dag = self.cwd / "dag.pdf"
+        assert dag.exists(), "dag.pdf was not generated"
+        assert dag.stat().st_size > 0, "dag.pdf is empty"


### PR DESCRIPTION
This PR attempts to fix a bug for which, especially if using Python 3.13+ the DAG generation via `showyourwork.yml` fails with a pickle-related error both locally and remotely.

Summary of changes:

- added new integration test for DAG generation (first commit - as expected `tests/integration/test_dag.py::TestDagGeneration::test_local` fails)
- updated `render_dag.yml` by removing version pins on everything
- updated `build.smk` in order to pin only `python` a-posteriori with the same version used by `showyourwork`

Closes #607 