### PR TITLE
Small updates to the documentation and dependencies

### DIFF
--- a/docs/changes/633.maintenance.rst
+++ b/docs/changes/633.maintenance.rst
@@ -1,0 +1,3 @@
+Removed datrie dependency as it is no longer required upstream.
+Added pyyaml dependency explicitely.
+Updated contributor installation instructions to use pip for docs and for code.

--- a/docs/contributorguide.rst
+++ b/docs/contributorguide.rst
@@ -7,6 +7,8 @@ Contributing to the documentation
 A great place to start contributing is to documentation. In order to do this you'll
 want to run the docs locally. Here are the steps for getting setup.
 
+.. _initial-setup:
+
 Initial setup
 ^^^^^^^^^^^^^
 
@@ -32,30 +34,12 @@ activate it
 
     conda activate sywdocs
 
-and install showyourwork for development
+and install showyourwork with the ``[docs]`` extra (if you plan on doing :ref:`code contributions<contributing-code>`, you can replace ``[docs]`` with ``[dev]``).
 
 .. code-block:: bash
 
     python -m pip install -e ".[docs]"
 
-
-Alternatively, you can create a conda environment
-
-.. code-block:: bash
-
-    conda create -n sywdocs -f docs/environment.yml
-
-activate it
-
-.. code-block:: bash
-
-    conda activate sywdocs
-
-and install showyourwork
-
-.. code-block:: bash
-
-    python -m pip install -e .
 
 During development
 ^^^^^^^^^^^^^^^^^^
@@ -107,10 +91,18 @@ Another great way to contribute is to raise or open issues. Showyourwork issues
 can be found `in the github repo <https://github.com/showyourwork/showyourwork/issues>`_. The
 "contributions welcome" tag is a great place to start!
 
+.. _contributing-code:
+
 Contributing code
 -----------------
 
-1. start from an up-to-date branch of the main branch
+To contribute code, you will need to install showyourwork in development mode.
+The simplest way to do this is to follow the :ref:`initial-setup` instructions,
+but replace the ``[docs]`` extra with the ``[dev]`` extra.
+
+Then, follow these instructions to make your code contribution:
+
+1. Start from an up-to-date branch of the main branch
    (name your branch something descriptive like 'fix-typo-in-docs' or 'add-new-feature')
 
 .. code-block:: sh
@@ -119,13 +111,13 @@ Contributing code
     git pull upstream main # here 'upstream' is the original repo remote name, NOT your fork
     git switch -c my-feature-branch
 
-2. make your changes trying to make small well-defined commits with descriptive messages
+2. Make your changes trying to make small well-defined commits with descriptive messages
    (this will make it easier to review and understand the changes)
    and following the project's coding style
 
-2. open a pull request against the main branch of the original repo
+2. Open a pull request against the main branch of the original repo
 
-3. add a news fragment in the ``docs/changes`` directory
+3. Add a news fragment in the ``docs/changes`` directory
 
    This is required for all PRs. The news fragment should be a file named
    ``<pull_request_number>.<type>.rst``, ``<type>`` is one of the following:

--- a/docs/contributorguide.rst
+++ b/docs/contributorguide.rst
@@ -20,10 +20,42 @@ Building the docs includes a few extra libraries that aren't required for |showy
 users, so its helpful to create a separate environment for those. You should only ever
 have to do this step once.
 
+The simplest way to get an environment is to first create it
+
 .. code-block:: bash
 
-    conda env create -n sywdocs -f docs/environment.yml
+    conda create -n sywdocs python pip
 
+activate it
+
+.. code-block:: bash
+
+    conda activate sywdocs
+
+and install showyourwork for development
+
+.. code-block:: bash
+
+    python -m pip install -e ".[docs]"
+
+
+Alternatively, you can create a conda environment
+
+.. code-block:: bash
+
+    conda create -n sywdocs -f docs/environment.yml
+
+activate it
+
+.. code-block:: bash
+
+    conda activate sywdocs
+
+and install showyourwork
+
+.. code-block:: bash
+
+    python -m pip install -e .
 
 During development
 ^^^^^^^^^^^^^^^^^^

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - pip
   - python>=3.11
-  - datrie
+  - pyyaml
   - requests
   - sphinx-book-theme
   - jinja2

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -189,7 +189,10 @@ please check out :doc:`reproducibility`.
 Issues with ``datrie``
 ----------------------
 
-The ``datrie`` package, a dependency  of ``snakemake``, does not currently (as of
+Note that snakemake no longer requires ``datrie`` as of version 9.
+The simplest way to avoid the issues discussed below is to use the latest showyourwork version and ``snakemake>9``.
+
+The ``datrie`` package, a dependency  of ``snakemake<9``, does not currently (as of
 the writing of these docs) have
 `wheels built for distributions of Python >= 3.9 <https://pypi.org/project/datrie/#files>`__.
 If you don't have a valid ``C/C++``
@@ -202,6 +205,7 @@ using ``conda``:
     conda install -c conda-forge datrie
 
 and then re-run ``pip install showyourwork``.
+
 
 
 `IncompleteFilesException`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ showyourwork = "showyourwork.cli:entry_point"
 [project.optional-dependencies]
 tests = ["matplotlib", "pytest>=7.0.0", "pytest-asyncio-cooperative>=0.28.0"]
 docs = [
-    "datrie",
     "sphinx-book-theme",
     "sphinxcontrib-programoutput",
     "sphinx-changelog",


### PR DESCRIPTION
This PR groups a few updates I made while going through the developer docs. Point 2 is a bit of a matter of preference between conda and pip requirements specifications, but I do feel it makes for a more coherent experience between docs and code contributions (see point 3).

1. Datrie is no longer required by snakemake upstream, so I removed the requirement and updated the docs entry to suggest to just update snakemake and showyourwork if people are having issues with datrie.
2. Since datrie is no longer required, it is easy to install all dependencies with pip. I updated the contributor docs to only document the `pip install -U -e ".[docs]"` installation method, which seems simpler and is applicable to "dev" mode and not just "docs" mode.
3. Update the code contribution instruction to mention the creation of an environment and installation of dev dependencies.
4. Add pyyaml as a requirement.

Thanks!