### PR TITLE
Attempt to fix `TestMatplotlibLatex` remote

### DIFF
--- a/docs/changes/641.bugfix.rst
+++ b/docs/changes/641.bugfix.rst
@@ -1,0 +1,1 @@
+Install underscore.sty latex package in test_latex.py

--- a/docs/changes/641.bugfix.rst
+++ b/docs/changes/641.bugfix.rst
@@ -1,1 +1,0 @@
-Install underscore.sty latex package in test_latex.py

--- a/tests/integration/test_latex.py
+++ b/tests/integration/test_latex.py
@@ -13,7 +13,7 @@ workflow_replace_with = """      - name: Install TinyTex for matplotlib LaTeX re
         shell: bash -l {0}
         run: |
           wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
-          sudo ~/bin/tlmgr install type1cm cm-super
+          sudo ~/bin/tlmgr install type1cm cm-super underscore
 
       - name: Build the article PDF
 """


### PR DESCRIPTION
In addition to zenodo remote tests in #635, `TestMatplotlibLatex` was failing due to a missing underscore.sty file. I think installing the package should fix the issue, but we would need to run the remote tests on this PR to know for sure (since running locally uses my own tex installation).

Thanks!