### PR TITLE
Fix `showyourwork build --dry-run`

### DIFF
--- a/docs/changes/649.bugfix.rst
+++ b/docs/changes/649.bugfix.rst
@@ -1,0 +1,1 @@
+Do not throw MissingConfigFile error when `--dry-run` is passed to Snakemake.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -88,3 +88,10 @@ Please comment line 405 in
 
 Once the Zenodo cache is frozen, no new Zenodo drafts are created by |showyourwork|.
 As a workaround while we work on a solution, we recommend users do not freeze the cache until it is ready to be published.
+
+`Snakemake's --dry-run argument completely skips the workflow #653 <https://github.com/showyourwork/showyourwork/issues/653>`_
+-----------------------------------------------------------------------------------------------------------
+
+showyourwork passes the `--dry-run` argument to snakemake, but internally it will skip the entire workflow.
+This results in a message saying no steps need to be run even when, in fact, steps would be run in an actual build.
+There is a warning printed at the CLI about this.

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -110,7 +110,7 @@ if (paths.user().temp / "config.json").exists():
 else:
 
 
-    if run_type != "clean" and not workflow.dryrun:
+    if run_type != "clean" and not workflow.output_settings.dryrun:
         raise exceptions.MissingConfigFile()
 
 

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -110,7 +110,7 @@ if (paths.user().temp / "config.json").exists():
 else:
 
 
-    if run_type != "clean":
+    if run_type != "clean" and not workflow.dryrun:
         raise exceptions.MissingConfigFile()
 
 

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -110,6 +110,12 @@ if (paths.user().temp / "config.json").exists():
 else:
 
 
+    if workflow.output_settings.dryrun:
+        get_logger().warn(
+            "--dry-run is only partially supported with showyourwork."
+            "The output will not be representative of what would actually run."
+        )
+
     if run_type != "clean" and not workflow.output_settings.dryrun:
         raise exceptions.MissingConfigFile()
 

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -181,15 +181,13 @@ class TemporaryShowyourworkRepository:
         args = ""
         if self.dry_run:
             args += " --dry-run"
-        import subprocess
 
-        subprocess.run(
+        get_stdout(
             f"{pre} CI=false showyourwork build" + args,
             shell=True,
             cwd=self.cwd,
-            check=False,
-            # env=env_var,
-            # callback=callback,
+            env=env_var,
+            callback=callback,
         )
 
     @pytest.mark.asyncio_cooperative

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -183,7 +183,7 @@ class TemporaryShowyourworkRepository:
             args += " --dry-run"
 
         get_stdout(
-            f"{pre} CI=false showyourwork build" + args,
+            "showyourwork build" + args,
             shell=True,
             cwd=self.cwd,
             env=env_var,

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -39,6 +39,7 @@ class TemporaryShowyourworkRepository:
     require_local_build = False
     delete_remote_on_success = False
     clear_actions_cache_on_start = True
+    dry_run = False
 
     # Internal
     _sandbox_concept_doi = None
@@ -177,12 +178,18 @@ class TemporaryShowyourworkRepository:
         env_var = {"CI": "false"}
         if env is not None:
             env_var.update(env)
-        get_stdout(
-            "showyourwork build",
+        args = ""
+        if self.dry_run:
+            args += " --dry-run"
+        import subprocess
+
+        subprocess.run(
+            f"{pre} CI=false showyourwork build" + args,
             shell=True,
             cwd=self.cwd,
-            callback=callback,
-            env=env_var,
+            check=False,
+            # env=env_var,
+            # callback=callback,
         )
 
     @pytest.mark.asyncio_cooperative

--- a/tests/integration/test_default.py
+++ b/tests/integration/test_default.py
@@ -5,3 +5,9 @@ class TestDefault(TemporaryShowyourworkRepository):
     """Test setting up and building the default repo."""
 
     pass
+
+
+class TestDefaultDry(TemporaryShowyourworkRepository):
+    """Test setting up and building the default repo with a dry-run"""
+
+    dry_run = True


### PR DESCRIPTION
Fixes #648.

This simply checks that we are not in a `--dry-run` before raising the `MissingConfigFile` error.

It will not, however, make the `--dry-run` much more informative: since `config.json` does not get generated basically nothing happens and a dry-run will always say there is nothing to do. This could be confusing so I would either:

1. Fix the dry-run so that a (potentially simpler) version of `prep.smk` always runs even during dry runs, so config.json gets created. This would let snakemake handle the dry-run as usual.
2. At least show a warning saying that currently dry-runs are not representative of what would actually happen.