### PR TITLE
Add option to run remote tests outside of showyourwork org

### DIFF
--- a/docs/changes/654.maintenance.rst
+++ b/docs/changes/654.maintenance.rst
@@ -1,0 +1,2 @@
+Add command line arguments to run the remote test as a regular user (`--no-org`) or with a specific org (`--github-org`).
+This allows users and contributors to run the remote tests without having to push a PR, making debugging easier.

--- a/docs/changes/654.maintenance.rst
+++ b/docs/changes/654.maintenance.rst
@@ -1,2 +1,2 @@
-Add command line arguments to run the remote test as a regular user (`--no-org`) or with a specific org (`--github-org`).
+Add command line arguments to run the remote tests as a regular user (`--no-org`) or with a specific org (`--github-org`).
 This allows users and contributors to run the remote tests without having to push a PR, making debugging easier.

--- a/docs/integration_tests.rst
+++ b/docs/integration_tests.rst
@@ -96,15 +96,38 @@ the output from the Python script.
 That's it! The parent class (``TemporaryShowyourworkRepository``) takes care
 of the rest.
 
-Note that several integration tests are marked with the ``remote`` mark (using ``pytest.mark``),
+Remote tests
+------------
+
+Note that several integration tests are marked with the ``remote`` mark (using ``pytest.mark``).
+This means that they will create a temporary remote repository on GitHub with
+the same name as the test (but in ``snake_case`` instead of ``camelCase``);
+if a repository already exists, the test will force-push new commits to it,
+mimicking the behavior of a newly created repository.
+
+Running locally
+^^^^^^^^^^^^^^^
+
+By default, the tests create the repository under the `github.com/showyourwork` organization,
 which means they require push access to the ``showyourwork`` organization in order
 to test the entire workflow, including the ``showyourwork-action`` and the generation
 of the PDF when running on the remote.
-Each of these tests creates a temporary repository in the
-`github.com/showyourwork` organization with the same name as the test
-(but in ``snake_case`` instead of ``camelCase``); if a repository already exists,
-the test will force-push new commits to it, mimicking the behavior of a newly
-created repository.
+
+Since most contributors and users do not have push access to the ``showyourowrk`` organization,
+there is also a flag to create the test repositories under a regular user.
+Users first need to
+`create a personal access token <https://github.com/settings/personal-access-tokens>`_
+with read access to your public repositories, and **read and write** access to actions,
+administration, code, and workflows.
+The token should then be stored under the ``GH_API_KEY`` environment variable.
+Once this is done, users should be able to run the integration tests with:
+
+.. code-block:: bash
+
+    python -m pytest tests/integration --remote --action-spec git+https://github.com/showyourwork/showyourwork.git --no-org
+
+Running via GitHub actions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Remote tests are spawned from the `remote_integration_tests.yml`
 workflow in `.github/workflows` of the ``showyourwork/showyourwork`` repository

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,11 +26,34 @@ def pytest_addoption(parser):
         default="showyourwork",
         help="version spec of showyourwork to install on GH Actions",
     )
+    parser.addoption(
+        "--github-org",
+        action="store",
+        default=None,
+        help="GitHub organization for test repos (defaults to 'showyourwork')",
+    )
+    parser.addoption(
+        "--no-org",
+        action="store_true",
+        default=False,
+        help="Use personal GitHub account instead of an organization",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "remote: a test that requires remote access")
     os.environ["ACTION_SPEC"] = str(config.getoption("--action-spec"))
+
+    # Set GITHUB_ORG from CLI option or environment variable
+    if config.getoption("--no-org"):
+        github_org = None
+    else:
+        github_org = config.getoption("--github-org")
+        if github_org is None:
+            github_org = os.getenv("SHOWYOURWORK_TEST_ORG", "showyourwork")
+        if github_org.lower() in ("none", ""):
+            github_org = None
+    os.environ["SHOWYOURWORK_TEST_ORG"] = github_org or ""
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -18,6 +18,18 @@ from showyourwork.zenodo import Zenodo
 SANDBOX = Path(__file__).absolute().parents[1] / "sandbox"
 RESOURCES = Path(__file__).absolute().parents[1] / "resources"
 
+# GitHub org can be set via:
+# 1. --github-org pytest CLI option (or --no-org to force personal account)
+# 2. SHOWYOURWORK_TEST_ORG environment variable (defaults to "showyourwork")
+# Set to empty string or "none" to use personal account
+GITHUB_ORG = os.getenv("SHOWYOURWORK_TEST_ORG", "showyourwork") or None
+GITHUB_USER = GITHUB_ORG or gitapi.get_authenticated_user()
+if GITHUB_USER is None:
+    raise TypeError(
+        "GITHUB_ORG is None and no github user found. "
+        "Specify an org or register an API token under GH_API_KEY"
+    )
+
 
 class TemporaryShowyourworkRepository:
     """
@@ -106,7 +118,7 @@ class TemporaryShowyourworkRepository:
         # Create a new one
         print(f"[{self.repo}] Creating local repo `tests/sandbox/{self.repo}`...")
         get_stdout(
-            f"{command} {options} showyourwork/{self.repo}",
+            f"{command} {options} {GITHUB_USER}/{self.repo}",
             cwd=self.root_path,
             shell=True,
         )
@@ -141,11 +153,11 @@ class TemporaryShowyourworkRepository:
         """Create the repo on GitHub if needed."""
         print(
             f"[{self.repo}] Setting up remote GitHub repo "
-            f"`showyourwork/{self.repo}`..."
+            f"`{GITHUB_USER}/{self.repo}`..."
         )
         gitapi.create_repo(
             self.repo,
-            org="showyourwork",
+            org=GITHUB_ORG,
             description="Temporary test repository for showyourwork",
             private=False,
         )
@@ -153,7 +165,7 @@ class TemporaryShowyourworkRepository:
     def clear_remote_cache(self):
         """Clear the remote GitHub Actions cache."""
         print(f"[{self.repo}] Clearing the Actions cache...")
-        gitapi.clear_cache(self.repo, org="showyourwork")
+        gitapi.clear_cache(self.repo, org=GITHUB_ORG)
 
     def git_commit(self):
         """Add and commit all files in the local repo."""
@@ -193,11 +205,11 @@ class TemporaryShowyourworkRepository:
         On success, returns, otherwise raises an Exception.
 
         """
-        print(f"[{self.repo}] Pushing to `showyourwork/{self.repo}`...")
+        print(f"[{self.repo}] Pushing to `{GITHUB_USER}/{self.repo}`...")
         get_stdout(
             "git push --force https://x-access-token:"
             f"{gitapi.get_access_token()}"
-            f"@github.com/showyourwork/{self.repo} main",
+            f"@github.com/{GITHUB_USER}/{self.repo} main",
             shell=True,
             cwd=self.cwd,
             secrets=[gitapi.get_access_token()],
@@ -218,7 +230,7 @@ class TemporaryShowyourworkRepository:
                 url,
             ) = gitapi.get_workflow_run_status(
                 self.repo,
-                org="showyourwork",
+                org=GITHUB_ORG,
                 q={"event": "push", "head_sha": head_sha},
             )
             if status == "completed":
@@ -234,12 +246,11 @@ class TemporaryShowyourworkRepository:
             elif n < self.action_max_tries - 1:
                 print(
                     f"[{self.repo}] Waiting {self.action_interval} seconds for "
-                    f"workflow to finish ({n+2}/{self.action_max_tries})..."
+                    f"workflow to finish ({n + 2}/{self.action_max_tries})..."
                 )
                 await asyncio.sleep(self.action_interval)
         raise Exception(
-            f"[{self.repo}] GitHub Actions workflow timed out.\n"
-            f"For details, see {url}"
+            f"[{self.repo}] GitHub Actions workflow timed out.\nFor details, see {url}"
         )
 
     def delete_zenodo(self):
@@ -253,8 +264,8 @@ class TemporaryShowyourworkRepository:
 
     def delete_remote(self):
         """Delete the remote repo."""
-        print(f"[{self.repo}] Deleting GitHub repo " f"`showyourwork/{self.repo}`...")
-        gitapi.delete_repo(self.repo, org="showyourwork")
+        print(f"[{self.repo}] Deleting GitHub repo `{GITHUB_USER}/{self.repo}`...")
+        gitapi.delete_repo(self.repo, org=GITHUB_ORG)
 
     def delete_local(self):
         """Delete the local repo."""


### PR DESCRIPTION
This PR adds a command line option to run remote tests with another GitHub org or as a regular user. The goal is to make it easier for contributors to run and debug the remote tests without having to rely on marking PRs safe to test.

For example, one could do this to run the default `test_remote` as a GitHub user.

```bash
python -m pytest tests/integration/test_default.py --remote --action-spec git+https://github.com/showyourwork/showyourwork.git -k test_remote --no-org
```

This requires users to setup an API token. I'll update the docs to mention this before marking the PR as ready for review.