### PR TITLE
Fix build crash when a figure is placed with [H]

### DIFF
--- a/docs/changes/656.bugfix.rst
+++ b/docs/changes/656.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where using ``\begin{figure}[H]`` would cause the build to crash
+with an XML parsing error during preprocessing.

--- a/src/showyourwork/workflow/resources/styles/preprocess.tex
+++ b/src/showyourwork/workflow/resources/styles/preprocess.tex
@@ -42,23 +42,14 @@
 }
 
 % Log figures
+% Use etoolbox hooks so that logging works regardless of how the figure
+% environment is internally implemented (e.g. the float package's [H]
+% specifier completely replaces \endfigure, which broke previous approaches).
 \ifcsmacro{figure}{
-  \let\oldfigure\figure
-  \let\oldendfigure\endfigure
-  \renewenvironment{figure}{%
-    \syw@LogMessage{<FIGURE>}%
-    \oldfigure%
-  }{%
-    \oldendfigure%
-    \syw@LogMessage{</FIGURE>}%
-  }
-  \renewenvironment{figure*}{%
-    \syw@LogMessage{<FIGURE>}%
-    \oldfigure%
-  }{%
-    \oldendfigure%
-    \syw@LogMessage{</FIGURE>}%
-  }
+  \AtBeginEnvironment{figure}{\syw@LogMessage{<FIGURE>}}
+  \AtEndEnvironment{figure}{\syw@LogMessage{</FIGURE>}}
+  \AtBeginEnvironment{figure*}{\syw@LogMessage{<FIGURE>}}
+  \AtEndEnvironment{figure*}{\syw@LogMessage{</FIGURE>}}
 }{}
 
 % Log equations

--- a/tests/integration/test_figure_placements.py
+++ b/tests/integration/test_figure_placements.py
@@ -1,0 +1,135 @@
+"""Integration tests for figures with different placement specifiers.
+
+Regression tests for issue #626: the float package's [H] specifier
+internally replaces \\endfigure, which bypassed the XML logging in
+preprocess.tex. The fix uses etoolbox environment hooks instead.
+"""
+
+from helpers import (
+    ShowyourworkRepositoryActions,
+    TemporaryShowyourworkRepository,
+)
+
+
+class TestFigurePlacementH(
+    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+):
+    """Test that figures with [H] placement build without XML parsing errors."""
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        # Add float package to preamble
+        ms = self.cwd / "src" / "tex" / "ms.tex"
+        content = ms.read_text()
+        content = content.replace(
+            r"\usepackage{showyourwork}",
+            r"\usepackage{showyourwork}" + "\n" + r"\usepackage{float}",
+        )
+        ms.write_text(content)
+
+        # Add a figure with [H] placement
+        lines = ms.read_text().splitlines()
+        figure_block = "\n".join(
+            [
+                r"\begin{figure}[H]",
+                r"\script{test_figure.py}",
+                r"\begin{centering}",
+                r"\includegraphics[width=\linewidth]{figures/test_figure.pdf}",
+                r"\caption{A test figure with [H] placement.}",
+                r"\label{fig:h_placement}",
+                r"\end{centering}",
+                r"\end{figure}",
+                "",
+            ]
+        )
+
+        for idx, line in enumerate(lines):
+            if line.strip() == r"\end{document}":
+                lines.insert(idx, figure_block)
+                break
+
+        ms.write_text("\n".join(lines) + "\n")
+
+        # Add the figure script
+        self.add_figure_script()
+
+
+class TestFigurePlacementMixed(
+    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+):
+    """Test figures with mixed placement specifiers including [H]."""
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        # Add float package to preamble
+        ms = self.cwd / "src" / "tex" / "ms.tex"
+        content = ms.read_text()
+        content = content.replace(
+            r"\usepackage{showyourwork}",
+            r"\usepackage{showyourwork}" + "\n" + r"\usepackage{float}",
+        )
+        ms.write_text(content)
+
+        # Add figures with different placement specifiers
+        lines = ms.read_text().splitlines()
+
+        # Figure without placement specifier (default)
+        fig1 = "\n".join(
+            [
+                r"\begin{figure}",
+                r"\script{test_figure.py}",
+                r"\begin{centering}",
+                r"\includegraphics[width=\linewidth]{figures/test_figure.pdf}",
+                r"\caption{Figure with default placement.}",
+                r"\label{fig:default}",
+                r"\end{centering}",
+                r"\end{figure}",
+                "",
+            ]
+        )
+
+        # Figure with [ht!]
+        fig2 = "\n".join(
+            [
+                r"\begin{figure}[ht!]",
+                r"\script{test_figure.py}",
+                r"\begin{centering}",
+                r"\includegraphics[width=\linewidth]{figures/test_figure.pdf}",
+                r"\caption{Figure with [ht!] placement.}",
+                r"\label{fig:ht}",
+                r"\end{centering}",
+                r"\end{figure}",
+                "",
+            ]
+        )
+
+        # Figure with [H] (float package)
+        fig3 = "\n".join(
+            [
+                r"\begin{figure}[H]",
+                r"\script{test_figure.py}",
+                r"\begin{centering}",
+                r"\includegraphics[width=\linewidth]{figures/test_figure.pdf}",
+                r"\caption{Figure with [H] placement.}",
+                r"\label{fig:h_exact}",
+                r"\end{centering}",
+                r"\end{figure}",
+                "",
+            ]
+        )
+
+        for idx, line in enumerate(lines):
+            if line.strip() == r"\end{document}":
+                lines.insert(idx, fig3)
+                lines.insert(idx, fig2)
+                lines.insert(idx, fig1)
+                break
+
+        ms.write_text("\n".join(lines) + "\n")
+
+        # Add the figure script
+        self.add_figure_script()


### PR DESCRIPTION
The float package's [H] specifier completely replaces `\endfigure` with its own `\float@endH` at runtime, so the `</FIGURE>` XML closing tag was never written, causing `xml.etree.ElementTree.ParseError: mismatched tag`.

I replaced the `\renewenvironment{figure}` approach in `preprocess.tex` with `etoolbox` hooks (`\AtBeginEnvironment` / `\AtEndEnvironment`), which are invoked by LaTeX's environment machinery regardless of how the environment is internally restructured.

I also added a new integration local-only test which tests for different figure placements (no specific placement, `[ht!]` and `[H]`).

Closes #626 