### PR TITLE
Properly pass `--dry-run` to snakemake for build step

### DIFF
--- a/docs/changes/649.bugfix.rst
+++ b/docs/changes/649.bugfix.rst
@@ -1,1 +1,1 @@
-Do not throw MissingConfigFile error when `--dry-run` is passed to Snakemake.
+Do not throw MissingConfigFile error when ``--dry-run`` is passed to Snakemake.

--- a/docs/changes/657.feature.rst
+++ b/docs/changes/657.feature.rst
@@ -1,0 +1,2 @@
+Execute ``prep.smk`` even with ``--dry-run`` and properly pass ``--dry-run`` to snakemake for the build step.
+Ensure that the snakemake output gets printed to STDOUT when ``--verbose`` is passed at the CLI.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -88,10 +88,3 @@ Please comment line 405 in
 
 Once the Zenodo cache is frozen, no new Zenodo drafts are created by |showyourwork|.
 As a workaround while we work on a solution, we recommend users do not freeze the cache until it is ready to be published.
-
-`Snakemake's --dry-run argument completely skips the workflow #653 <https://github.com/showyourwork/showyourwork/issues/653>`_
------------------------------------------------------------------------------------------------------------
-
-showyourwork passes the `--dry-run` argument to snakemake, but internally it will skip the entire workflow.
-This results in a message saying no steps need to be run even when, in fact, steps would be run in an actual build.
-There is a warning printed at the CLI about this.

--- a/src/showyourwork/cli/commands/preprocess.py
+++ b/src/showyourwork/cli/commands/preprocess.py
@@ -8,6 +8,9 @@ def preprocess(snakemake_args=(), cores=1, conda_frontend="conda"):
     Args:
         snakemake_args (list, optional): Additional options to pass to Snakemake.
     """
+    snakemake_args = tuple(
+        arg for arg in snakemake_args if arg not in ["--dry-run", "-n"]
+    )
     snakefile = paths.showyourwork().workflow / "prep.smk"
     run_snakemake(
         snakefile.as_posix(),

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -167,7 +167,7 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                     # Cache miss; not fatal
                     exceptions.restore_trace()
                     logger.warning(
-                        "Required version of file not found in cache: " f"{outputfile}."
+                        f"Required version of file not found in cache: {outputfile}."
                     )
                     if config.get("github_actions") and not config.get(
                         "run_cache_rules_on_ci"
@@ -279,11 +279,13 @@ def patch_snakemake_logging():
 
     # Suppress *all* Snakemake output to the terminal (unless verbose);
     # save it all for the logs!
+    verbose = snakemake.workflow.config.get("verbose", False)  # From showyourwork.yml
+    verbose = verbose or snakemake.workflow.workflow.output_settings.verbose  # from CLI
     if hasattr(snakemake_logger, "handlers"):
         for handler in snakemake_logger.handlers:
             if isinstance(handler, logging.FileHandler):
                 handler.setLevel(logging.DEBUG)
-            elif not snakemake.workflow.config.get("verbose", False):
+            elif not verbose:
                 handler.setLevel(logging.CRITICAL)
     elif hasattr(snakemake_logger, "logger") and hasattr(
         snakemake_logger.logger, "handlers"
@@ -293,7 +295,7 @@ def patch_snakemake_logging():
         for handler in snakemake_logger.logger.handlers:
             if isinstance(handler, logging.FileHandler):
                 handler.setLevel(logging.DEBUG)
-            elif not snakemake.workflow.config.get("verbose", False):
+            elif not verbose:
                 handler.setLevel(logging.CRITICAL)
 
     # Custom Snakemake stdout handler

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -109,14 +109,7 @@ if (paths.user().temp / "config.json").exists():
 
 else:
 
-
-    if workflow.output_settings.dryrun:
-        get_logger().warn(
-            "--dry-run is only partially supported with showyourwork."
-            "The output will not be representative of what would actually run."
-        )
-
-    if run_type != "clean" and not workflow.output_settings.dryrun:
+    if run_type != "clean":
         raise exceptions.MissingConfigFile()
 
 

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -181,7 +181,6 @@ class TemporaryShowyourworkRepository:
         args = ""
         if self.dry_run:
             args += " --dry-run"
-
         get_stdout(
             "showyourwork build" + args,
             shell=True,


### PR DESCRIPTION
This fixes #653 by passing the `--dry-run` flag to snakemake for the build step. Here is what happens:

1. `--dry-run` or `-n` gets filtered out for the `prep.smk` step: we need this step to run to generate `config.json`.
2. `--dry-run` gets passed to `snakemake` like any other argument for the `build.smk` step so that the workflow runs in dry-run mode as any other snakemake workflow would.

By default, `showyourwork` suppresses Snakemake outputs, so dry-runs will not be very informative. To see more info, users can:

- Look at `.showyourwork/logs/snakemake.log`
- Set `verbose: true` in `showyourwork.yml`
- Pass `--verbose` as a CLI argument.

Before this PR, passing `--verbose` would only affect the output of the `snakemake.log` file unless `verbose: true` was set in the YAML file. This seems counter-intuitive from a user perspective: if I pass `--verbose`, I usually expect the program to print more things to STDOUT. I changed the code slightly so that passing `--verbose` to snakemake would also print snakemake output to STDOUT. This also allows users to quickly check the snakemake output for a single build execution without messing with their config.