### PR TITLE
Add 'safe to test' label to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "no-changelog-needed"
+      - "safe to test"


### PR DESCRIPTION
These automatic changes meddle with actions related to push/pull of artifacts and similar operations from/to local/remote repositories, therefore we should allow the PRs to run the remote tests automatically to make sure we do not break something due to new versions'features