### PR TITLE
Fix PR links in the changelog

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -3,7 +3,7 @@ package = "showyourwork"
 directory = "docs/changes"
 filename = "CHANGES.rst"
 # let towncrier create proper links to the merged PR
-issue_format = "`#{issue} <https://github.com/showyourwork/showyourwork/pulls/{issue}>`__"
+issue_format = "`#{issue} <https://github.com/showyourwork/showyourwork/pull/{issue}>`__"
 
 [tool.towncrier.fragment.feature]
 name = "New Features"


### PR DESCRIPTION
Right now in the main documentation if you go to any new changelog entry it will point to a PR search with filters

`is:open is:pr author:xxx`

where xxx is the number ID of the PR!

The main issue is caused by the fact that the link url contains `pulls` instead of `pull` so it looks for PRs made by an author but it's name is taken by the news fragment / PR id.

Apologies for not having realized this sooner 🙏 