### PR TITLE
Fix cleanup-metadata error formatting message

### DIFF
--- a/docs/changes/669.documentation.rst
+++ b/docs/changes/669.documentation.rst
@@ -1,0 +1,3 @@
+Fixed a formatting error message which was erroneously suggesting
+to call ``showyourwork --cleanup-metadata`` in case of incomplete files.
+Of course it has always been ``showyourwork build --cleanup-metadata``.

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -37,7 +37,7 @@ class SnakemakeFormatter(logging.Formatter):
     """
 
     replacements = {
-        "snakemake --cleanup-metadata": "showyourwork --cleanup-metadata",
+        "snakemake --cleanup-metadata": "showyourwork build --cleanup-metadata",
     }
 
     def format(self, record):


### PR DESCRIPTION
very easy fix, just a wrong error formatting alias suggested to the user when `snakemake` raises an error about incomplete files

Closes #453 