### PR TITLE
Allow for dependencies to be entire directories

### DIFF
--- a/docs/changes/670.feature.rst
+++ b/docs/changes/670.feature.rst
@@ -1,4 +1,4 @@
 Dependencies in ``showyourwork.yml`` can be specified as entire directories.
-When a directory is specified (with a trailing slash, e.g., ``src/scripts/utils/``),
+When a directory is specified (e.g., ``src/scripts/utils/``, with or without a trailing slash),
 all files within that directory are treated as dependencies, eliminating the need to
 enumerate each helper script individually if they are too many to make it comfortable to do.

--- a/docs/changes/670.feature.rst
+++ b/docs/changes/670.feature.rst
@@ -1,0 +1,4 @@
+Dependencies in ``showyourwork.yml`` can be specified as entire directories.
+When a directory is specified (with a trailing slash, e.g., ``src/scripts/utils/``),
+all files within that directory are treated as dependencies, eliminating the need to
+enumerate each helper script individually if they are too many to make it comfortable to do.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -402,11 +402,15 @@ the path to a script (either a figure script or the TeX manuscript itself)
 relative to the repository root. Following each entry, provide a list of
 all files on which the script depends. These dependencies may either be
 static (such as helper scripts) or programmatically generated (such as
-datsets downloaded from Zenodo). In the latter case, instructions on how
+datasets downloaded from Zenodo). In the latter case, instructions on how
 to generate them must be provided elsewhere (either via the ``zenodo`` key
 below or via a custom ``rule`` in the ``Snakefile``). In both cases, changes
 to the dependency will result in a re-run of the section of the workflow that
 executes the script.
+
+Dependencies may be specified as individual files or as entire directories.
+When a directory is specified, all files within it will be treated as
+dependencies of the script.
 
 **Required:** no
 
@@ -421,6 +425,15 @@ the helper script ``utils/helper_script.py``:
   dependencies:
     src/scripts/my_figure.py:
       - src/scripts/utils/helper_script.py
+
+You can also specify a dependency on an entire directory. All files within
+the directory will be treated as dependencies:
+
+.. code-block:: yaml
+
+  dependencies:
+    src/scripts/my_figure.py:
+      - src/scripts/utils/
 
 You can also specify a dependency on a programmatically-generated file:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -427,7 +427,7 @@ the helper script ``utils/helper_script.py``:
       - src/scripts/utils/helper_script.py
 
 You can also specify a dependency on an entire directory. All files within
-the directory will be treated as dependencies:
+the directory will be treated as dependencies (the trailing slash is optional):
 
 .. code-block:: yaml
 

--- a/src/showyourwork/config.py
+++ b/src/showyourwork/config.py
@@ -149,6 +149,49 @@ def as_dict(x, depth=0, maxdepth=30):
     return x
 
 
+def expand_dependency_directories(dependency, repo_root=None):
+    """
+    Expand a dependency path that may be a directory into a list of files.
+
+    If the dependency is a directory, recursively returns all files within it.
+    Otherwise, returns the dependency as-is in a list.
+
+    Args:
+        dependency (str): Path to a file or directory, relative to the repo root.
+            Should use forward slashes (/) as path separators for consistency
+            across platforms.
+        repo_root (Path, optional): Root path of the repository. If not provided,
+            defaults to the user's repo root via paths.user().repo.
+
+    Returns:
+        list: A list of file paths (as strings) with forward slashes as separators
+            for platform-independent consistency.
+
+    """
+    if repo_root is None:
+        repo_root = paths.user().repo
+    else:
+        repo_root = Path(repo_root)
+
+    # Normalize dependency to use forward slashes (platform-independent representation)
+    # pathlib.Path handles both forward and backward slashes on all platforms
+    dep_path = repo_root / dependency.replace("\\", "/")
+
+    if dep_path.is_dir():
+        # Get all files in the directory recursively
+        files = []
+        for file_path in sorted(dep_path.rglob("*")):
+            if file_path.is_file():
+                # Return relative path from repo root with forward slashes
+                # This ensures consistency across Windows, macOS, and Linux
+                rel_path = file_path.relative_to(repo_root)
+                files.append(rel_path.as_posix())
+        return files
+    else:
+        # Not a directory, return as-is with forward slashes normalized
+        return [dependency.replace("\\", "/")]
+
+
 def get_upstream_dependencies(file, dependencies, depth=0):
     """
     Collect user-defined dependencies of a file recursively.
@@ -158,8 +201,12 @@ def get_upstream_dependencies(file, dependencies, depth=0):
     if deps := dependencies.get(file, []):
         res = set()
         for dep in deps:
-            res |= set([dep])
-            res |= get_upstream_dependencies(dep, dependencies, depth + 1)
+            # Expand directories into individual files
+            expanded_deps = expand_dependency_directories(dep)
+            res |= set(expanded_deps)
+            # Recursively get dependencies of each expanded dependency
+            for expanded_dep in expanded_deps:
+                res |= get_upstream_dependencies(expanded_dep, dependencies, depth + 1)
     else:
         res = set()
     if not depth:

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from snakemake.iocontainers import snakemake
 
 from showyourwork import exceptions, paths, zenodo
-from showyourwork.config import get_upstream_dependencies
+from showyourwork.config import expand_dependency_directories, get_upstream_dependencies
 from showyourwork.zenodo import Zenodo, get_dataset_urls
 
 
@@ -388,6 +388,12 @@ def get_json_tree(xmlfile):
         dependencies = config["dependencies"].get(script, [])
         if isinstance(dependencies, str):
             dependencies = [dependencies]
+
+        # Expand any directory dependencies into individual files
+        expanded_dependencies = []
+        for dep in dependencies:
+            expanded_dependencies.extend(expand_dependency_directories(dep))
+        dependencies = expanded_dependencies
         dependencies += list(extra_dependencies)
 
         # Same, but recursing all the way up the graph

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -281,7 +281,6 @@ def get_json_tree(xmlfile):
         # Find all graphics included in this figure environment
         graphics = [
             (paths.user().tex / graphicspath / graphic.text)
-            .resolve()
             .relative_to(paths.user().repo)
             .as_posix()
             for graphic in figure.findall("GRAPHICS")
@@ -426,7 +425,6 @@ def get_json_tree(xmlfile):
     # Parse free-floating graphics
     free_floating_graphics = [
         (paths.user().tex / graphicspath / graphic.text)
-        .resolve()
         .relative_to(paths.user().repo)
         .as_posix()
         for graphic in xml_tree.findall("GRAPHICS")
@@ -494,7 +492,6 @@ def get_json_tree(xmlfile):
     # these will be made explicit dependencies of the build
     files = [
         (paths.user().tex / file.text)
-        .resolve()
         .relative_to(paths.user().repo)
         .as_posix()
         for file in xml_tree.findall("INPUT")

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -491,9 +491,7 @@ def get_json_tree(xmlfile):
     # Parse files included using the \input statement;
     # these will be made explicit dependencies of the build
     files = [
-        (paths.user().tex / file.text)
-        .relative_to(paths.user().repo)
-        .as_posix()
+        (paths.user().tex / file.text).relative_to(paths.user().repo).as_posix()
         for file in xml_tree.findall("INPUT")
     ]
 

--- a/tests/integration/test_directory_dependencies.py
+++ b/tests/integration/test_directory_dependencies.py
@@ -1,0 +1,250 @@
+"""Tests for directory dependencies feature.
+
+These tests verify that dependencies can be specified as entire directories,
+with all files within the directory treated as dependencies of a script.
+
+The tests are designed to be cross-platform compatible (Windows, macOS, Linux)
+by using pathlib for filesystem operations and forward slashes (/) in YAML
+configuration paths.
+"""
+
+import yaml
+from helpers import (
+    ShowyourworkRepositoryActions,
+    TemporaryShowyourworkRepository,
+)
+
+
+class TestDirectoryDependency(
+    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+):
+    """
+    Test that a dependency can be specified as a directory.
+
+    When a directory is specified as a dependency in the showyourwork.yml,
+    all files within that directory should be treated as dependencies of the
+    dict key. This allows users to specify the entire
+    utils directory rather than listing each helper script individually.
+    """
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        """Create figure script, helper scripts, and dependencies config."""
+
+        # Create helper scripts in a utils subdirectory
+        utils_dir = self.cwd / "src" / "scripts" / "utils"
+        utils_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create first helper script
+        (utils_dir / "helper1.py").write_text(
+            "def helper1_function():\n    return 'Hello from helper1'\n"
+        )
+
+        # Create second helper script
+        (utils_dir / "helper2.py").write_text(
+            "def helper2_function():\n    return 'World from helper2'\n"
+        )
+
+        # Create a nested helper script
+        nested_dir = utils_dir / "nested"
+        nested_dir.mkdir(parents=True, exist_ok=True)
+        (nested_dir / "helper3.py").write_text(
+            "def helper3_function():\n    return 'Deep helper from helper3'\n"
+        )
+
+        # Create the main figure script that imports from utils
+        with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
+            f.write(
+                "import sys\n"
+                "from pathlib import Path\n"
+                "sys.path.insert(0, str(Path.cwd() / 'src' / 'scripts'))\n"
+                "from utils.helper1 import helper1_function\n"
+                "from utils.helper2 import helper2_function\n"
+                "from utils.nested.helper3 import helper3_function\n"
+                "import matplotlib.pyplot as plt\n"
+                "import numpy as np\n"
+                "import paths\n"
+                "np.random.seed(0)\n"
+                "# Use the helper functions\n"
+                "msg1 = helper1_function()\n"
+                "msg2 = helper2_function()\n"
+                "msg3 = helper3_function()\n"
+                "# Create a simple figure\n"
+                "fig = plt.figure(figsize=(7, 6))\n"
+                "plt.plot([1, 2, 3, 4], [1, 4, 2, 3])\n"
+                "plt.title(f'{msg1} {msg2} {msg3}')\n"
+                "fig.savefig(paths.figures / 'test_figure.pdf', "
+                "bbox_inches='tight', dpi=300)\n"
+            )
+
+        # Add figure environment to the TeX file
+        self.add_figure_environment()
+
+        # Add dependency on the entire utils directory
+        # This is the key feature being tested - specifying a directory
+        # instead of individual files
+        config_path = self.cwd / "showyourwork.yml"
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        config["dependencies"] = {
+            "src/scripts/test_figure.py": [
+                "src/scripts/utils/",  # Specify the entire utils directory
+            ],
+        }
+
+        with open(config_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
+
+    def check_build(self):
+        """Verify that the figure was generated successfully."""
+        # The figure should have been generated
+        assert (
+            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
+        ).exists(), "Figure was not generated despite having directory dependency"
+
+
+class TestDirectoryDependencyMultiple(
+    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+):
+    """
+    Test that multiple directory dependencies work correctly.
+
+    This verifies that a script can depend on multiple directories,
+    and all files within each directory are properly tracked.
+    """
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        """Create multiple directories with helper scripts."""
+
+        # Create first utils directory
+        utils_dir = self.cwd / "src" / "scripts" / "utils"
+        utils_dir.mkdir(parents=True, exist_ok=True)
+        (utils_dir / "helper.py").write_text("def helper_func():\n    return 'data'\n")
+
+        # Create a config directory
+        config_dir = self.cwd / "src" / "scripts" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "settings.py").write_text("PLOT_SIZE = (7, 6)\n")
+
+        # Create the main figure script
+        with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
+            f.write(
+                "import sys\n"
+                "from pathlib import Path\n"
+                "sys.path.insert(0, str(Path.cwd() / 'src' / 'scripts'))\n"
+                "from utils.helper import helper_func\n"
+                "from config.settings import PLOT_SIZE\n"
+                "import matplotlib.pyplot as plt\n"
+                "import numpy as np\n"
+                "import paths\n"
+                "np.random.seed(0)\n"
+                "data = helper_func()\n"
+                "fig = plt.figure(figsize=PLOT_SIZE)\n"
+                "plt.plot([1, 2, 3])\n"
+                "fig.savefig(paths.figures / 'test_figure.pdf', "
+                "bbox_inches='tight', dpi=300)\n"
+            )
+
+        # Add figure environment
+        self.add_figure_environment()
+
+        # Add dependencies on multiple directories
+        config_path = self.cwd / "showyourwork.yml"
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        config["dependencies"] = {
+            "src/scripts/test_figure.py": [
+                "src/scripts/utils/",
+                "src/scripts/config/",  # Multiple directories
+            ],
+        }
+
+        with open(config_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
+
+    def check_build(self):
+        """Verify that the figure was generated successfully."""
+        assert (
+            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
+        ).exists(), "Figure was not generated with multiple directory dependencies"
+
+
+class TestMixedFilesAndDirectories(
+    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+):
+    """
+    Test that file and directory dependencies can be mixed.
+
+    A script can depend on both individual files and entire directories
+    in the same dependency list.
+    """
+
+    # No need to test this on CI
+    local_build_only = True
+
+    def customize(self):
+        """Create both individual files and directories."""
+
+        # Create a standalone helper file
+        (self.cwd / "src" / "scripts").mkdir(parents=True, exist_ok=True)
+        (self.cwd / "src" / "scripts" / "standalone_helper.py").write_text(
+            "def standalone():\n    return 'standalone'\n"
+        )
+
+        # Create a utils directory with multiple helpers
+        utils_dir = self.cwd / "src" / "scripts" / "utils"
+        utils_dir.mkdir(parents=True, exist_ok=True)
+        (utils_dir / "helper.py").write_text("def from_utils():\n    return 'utils'\n")
+
+        # Create the main figure script
+        with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
+            f.write(
+                "import sys\n"
+                "from pathlib import Path\n"
+                "sys.path.insert(0, str(Path.cwd() / 'src' / 'scripts'))\n"
+                "from standalone_helper import standalone\n"
+                "from utils.helper import from_utils\n"
+                "import matplotlib.pyplot as plt\n"
+                "import numpy as np\n"
+                "import paths\n"
+                "np.random.seed(0)\n"
+                "msg1 = standalone()\n"
+                "msg2 = from_utils()\n"
+                "fig = plt.figure(figsize=(7, 6))\n"
+                "plt.plot([1, 2, 3])\n"
+                "fig.savefig(paths.figures / 'test_figure.pdf', "
+                "bbox_inches='tight', dpi=300)\n"
+            )
+
+        # Add figure environment
+        self.add_figure_environment()
+
+        # Add dependencies mixing files and directories
+        config_path = self.cwd / "showyourwork.yml"
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        config["dependencies"] = {
+            "src/scripts/test_figure.py": [
+                "src/scripts/standalone_helper.py",  # Individual file
+                "src/scripts/utils/",  # Directory
+            ],
+        }
+
+        with open(config_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
+
+    def check_build(self):
+        """Verify that the figure was generated successfully."""
+        assert (
+            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
+        ).exists(), (
+            "Figure was not generated with mixed file and directory dependencies"
+        )

--- a/tests/integration/test_directory_dependencies.py
+++ b/tests/integration/test_directory_dependencies.py
@@ -2,59 +2,62 @@
 
 These tests verify that dependencies can be specified as entire directories,
 with all files within the directory treated as dependencies of a script.
-
-The tests are designed to be cross-platform compatible (Windows, macOS, Linux)
-by using pathlib for filesystem operations and forward slashes (/) in YAML
-configuration paths.
 """
 
-import yaml
 from helpers import (
     ShowyourworkRepositoryActions,
     TemporaryShowyourworkRepository,
 )
+
+from showyourwork.config import edit_yaml
 
 
 class TestDirectoryDependency(
     TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
 ):
     """
-    Test that a dependency can be specified as a directory.
+    Test that dependencies can be specified as directories.
 
-    When a directory is specified as a dependency in the showyourwork.yml,
-    all files within that directory should be treated as dependencies of the
-    dict key. This allows users to specify the entire
-    utils directory rather than listing each helper script individually.
+    Covers three use cases:
+    - directory dependency with nested subdirectories
+    - multiple directory dependencies
+    - mixed individual file and directory dependencies
+
+    Also verifies that modifying a file inside a dependency directory
+    triggers a rebuild of the figure.
     """
 
     # No need to test this on CI
     local_build_only = True
 
-    def customize(self):
-        """Create figure script, helper scripts, and dependencies config."""
-
-        # Create helper scripts in a utils subdirectory
+    def _create_helper_scripts(self):
+        """Create helper scripts in utils/ and config/ directories."""
         utils_dir = self.cwd / "src" / "scripts" / "utils"
         utils_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create first helper script
         (utils_dir / "helper1.py").write_text(
             "def helper1_function():\n    return 'Hello from helper1'\n"
         )
-
-        # Create second helper script
         (utils_dir / "helper2.py").write_text(
             "def helper2_function():\n    return 'World from helper2'\n"
         )
 
-        # Create a nested helper script
         nested_dir = utils_dir / "nested"
         nested_dir.mkdir(parents=True, exist_ok=True)
         (nested_dir / "helper3.py").write_text(
             "def helper3_function():\n    return 'Deep helper from helper3'\n"
         )
 
-        # Create the main figure script that imports from utils
+        config_dir = self.cwd / "src" / "scripts" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "settings.py").write_text("PLOT_SIZE = (7, 6)\n")
+
+        (self.cwd / "src" / "scripts" / "standalone_helper.py").write_text(
+            "def standalone():\n    return 'standalone'\n"
+        )
+
+    def _create_figure_script(self, seed=0):
+        """Create the main figure script that imports from helpers."""
         with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
             f.write(
                 "import sys\n"
@@ -63,188 +66,62 @@ class TestDirectoryDependency(
                 "from utils.helper1 import helper1_function\n"
                 "from utils.helper2 import helper2_function\n"
                 "from utils.nested.helper3 import helper3_function\n"
+                "from config.settings import PLOT_SIZE\n"
+                "from standalone_helper import standalone\n"
                 "import matplotlib.pyplot as plt\n"
                 "import numpy as np\n"
                 "import paths\n"
-                "np.random.seed(0)\n"
-                "# Use the helper functions\n"
+                f"np.random.seed({seed})\n"
                 "msg1 = helper1_function()\n"
                 "msg2 = helper2_function()\n"
                 "msg3 = helper3_function()\n"
-                "# Create a simple figure\n"
-                "fig = plt.figure(figsize=(7, 6))\n"
-                "plt.plot([1, 2, 3, 4], [1, 4, 2, 3])\n"
-                "plt.title(f'{msg1} {msg2} {msg3}')\n"
-                "fig.savefig(paths.figures / 'test_figure.pdf', "
-                "bbox_inches='tight', dpi=300)\n"
-            )
-
-        # Add figure environment to the TeX file
-        self.add_figure_environment()
-
-        # Add dependency on the entire utils directory
-        # This is the key feature being tested - specifying a directory
-        # instead of individual files
-        config_path = self.cwd / "showyourwork.yml"
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
-
-        config["dependencies"] = {
-            "src/scripts/test_figure.py": [
-                "src/scripts/utils/",  # Specify the entire utils directory
-            ],
-        }
-
-        with open(config_path, "w") as f:
-            yaml.dump(config, f, default_flow_style=False)
-
-    def check_build(self):
-        """Verify that the figure was generated successfully."""
-        # The figure should have been generated
-        assert (
-            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
-        ).exists(), "Figure was not generated despite having directory dependency"
-
-
-class TestDirectoryDependencyMultiple(
-    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
-):
-    """
-    Test that multiple directory dependencies work correctly.
-
-    This verifies that a script can depend on multiple directories,
-    and all files within each directory are properly tracked.
-    """
-
-    # No need to test this on CI
-    local_build_only = True
-
-    def customize(self):
-        """Create multiple directories with helper scripts."""
-
-        # Create first utils directory
-        utils_dir = self.cwd / "src" / "scripts" / "utils"
-        utils_dir.mkdir(parents=True, exist_ok=True)
-        (utils_dir / "helper.py").write_text("def helper_func():\n    return 'data'\n")
-
-        # Create a config directory
-        config_dir = self.cwd / "src" / "scripts" / "config"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        (config_dir / "settings.py").write_text("PLOT_SIZE = (7, 6)\n")
-
-        # Create the main figure script
-        with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
-            f.write(
-                "import sys\n"
-                "from pathlib import Path\n"
-                "sys.path.insert(0, str(Path.cwd() / 'src' / 'scripts'))\n"
-                "from utils.helper import helper_func\n"
-                "from config.settings import PLOT_SIZE\n"
-                "import matplotlib.pyplot as plt\n"
-                "import numpy as np\n"
-                "import paths\n"
-                "np.random.seed(0)\n"
-                "data = helper_func()\n"
+                "msg4 = standalone()\n"
                 "fig = plt.figure(figsize=PLOT_SIZE)\n"
-                "plt.plot([1, 2, 3])\n"
+                "plt.plot(np.random.randn(10))\n"
+                "plt.title(f'{msg1} {msg2} {msg3} {msg4}')\n"
                 "fig.savefig(paths.figures / 'test_figure.pdf', "
                 "bbox_inches='tight', dpi=300)\n"
             )
 
-        # Add figure environment
-        self.add_figure_environment()
-
-        # Add dependencies on multiple directories
-        config_path = self.cwd / "showyourwork.yml"
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
-
-        config["dependencies"] = {
-            "src/scripts/test_figure.py": [
-                "src/scripts/utils/",
-                "src/scripts/config/",  # Multiple directories
-            ],
-        }
-
-        with open(config_path, "w") as f:
-            yaml.dump(config, f, default_flow_style=False)
-
-    def check_build(self):
-        """Verify that the figure was generated successfully."""
-        assert (
-            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
-        ).exists(), "Figure was not generated with multiple directory dependencies"
-
-
-class TestMixedFilesAndDirectories(
-    TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
-):
-    """
-    Test that file and directory dependencies can be mixed.
-
-    A script can depend on both individual files and entire directories
-    in the same dependency list.
-    """
-
-    # No need to test this on CI
-    local_build_only = True
+    def _configure_dependencies(self):
+        """Set up mixed file and directory dependencies in showyourwork.yml."""
+        with edit_yaml(self.cwd / "showyourwork.yml") as config:
+            config["dependencies"] = {
+                "src/scripts/test_figure.py": [
+                    "src/scripts/utils/",  # Directory dependency (with nested subdir)
+                    "src/scripts/config/",  # Second directory dependency
+                    "src/scripts/standalone_helper.py",  # Individual file dependency
+                ],
+            }
 
     def customize(self):
-        """Create both individual files and directories."""
+        """Create figure script, helper scripts, and dependencies config."""
+        self._create_helper_scripts()
+        self._create_figure_script(seed=0)
+        self.add_figure_environment()
+        self._configure_dependencies()
 
-        # Create a standalone helper file
-        (self.cwd / "src" / "scripts").mkdir(parents=True, exist_ok=True)
-        (self.cwd / "src" / "scripts" / "standalone_helper.py").write_text(
-            "def standalone():\n    return 'standalone'\n"
+    def check_build(self):
+        """Verify build and that modifying a dependency triggers a rebuild."""
+        figure_path = self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
+        assert figure_path.exists(), (
+            "Figure was not generated with directory dependencies"
         )
 
-        # Create a utils directory with multiple helpers
-        utils_dir = self.cwd / "src" / "scripts" / "utils"
-        utils_dir.mkdir(parents=True, exist_ok=True)
-        (utils_dir / "helper.py").write_text("def from_utils():\n    return 'utils'\n")
+        # Record the modification time of the generated figure
+        mtime_before = figure_path.stat().st_mtime
 
-        # Create the main figure script
-        with open(self.cwd / "src" / "scripts" / "test_figure.py", "w") as f:
-            f.write(
-                "import sys\n"
-                "from pathlib import Path\n"
-                "sys.path.insert(0, str(Path.cwd() / 'src' / 'scripts'))\n"
-                "from standalone_helper import standalone\n"
-                "from utils.helper import from_utils\n"
-                "import matplotlib.pyplot as plt\n"
-                "import numpy as np\n"
-                "import paths\n"
-                "np.random.seed(0)\n"
-                "msg1 = standalone()\n"
-                "msg2 = from_utils()\n"
-                "fig = plt.figure(figsize=(7, 6))\n"
-                "plt.plot([1, 2, 3])\n"
-                "fig.savefig(paths.figures / 'test_figure.pdf', "
-                "bbox_inches='tight', dpi=300)\n"
-            )
+        # Modify a helper inside a dependency directory
+        (self.cwd / "src" / "scripts" / "utils" / "helper1.py").write_text(
+            "def helper1_function():\n    return 'Modified helper1'\n"
+        )
 
-        # Add figure environment
-        self.add_figure_environment()
+        # Commit and rebuild
+        self.git_commit()
+        self.build_local()
 
-        # Add dependencies mixing files and directories
-        config_path = self.cwd / "showyourwork.yml"
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
-
-        config["dependencies"] = {
-            "src/scripts/test_figure.py": [
-                "src/scripts/standalone_helper.py",  # Individual file
-                "src/scripts/utils/",  # Directory
-            ],
-        }
-
-        with open(config_path, "w") as f:
-            yaml.dump(config, f, default_flow_style=False)
-
-    def check_build(self):
-        """Verify that the figure was generated successfully."""
-        assert (
-            self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
-        ).exists(), (
-            "Figure was not generated with mixed file and directory dependencies"
+        # The figure should have been regenerated
+        mtime_after = figure_path.stat().st_mtime
+        assert mtime_after > mtime_before, (
+            "Figure was not regenerated after modifying a dependency inside a directory"
         )

--- a/tests/integration/test_directory_dependencies.py
+++ b/tests/integration/test_directory_dependencies.py
@@ -104,9 +104,9 @@ class TestDirectoryDependency(
     def check_build(self):
         """Verify build and that modifying a dependency triggers a rebuild."""
         figure_path = self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
-        assert figure_path.exists(), (
-            "Figure was not generated with directory dependencies"
-        )
+        assert (
+            figure_path.exists()
+        ), "Figure was not generated with directory dependencies"
 
         # Record the modification time of the generated figure
         mtime_before = figure_path.stat().st_mtime
@@ -122,6 +122,6 @@ class TestDirectoryDependency(
 
         # The figure should have been regenerated
         mtime_after = figure_path.stat().st_mtime
-        assert mtime_after > mtime_before, (
-            "Figure was not regenerated after modifying a dependency inside a directory"
-        )
+        assert (
+            mtime_after > mtime_before
+        ), "Figure was not regenerated after modifying a dependency inside a directory"

--- a/tests/integration/test_include.py
+++ b/tests/integration/test_include.py
@@ -40,7 +40,7 @@ class TestInclude(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         # Make the dataset a dependency of the figure
         with edit_yaml(self.cwd / "showyourwork.yml") as config:
             config["dependencies"] = {
-                "src/scripts/test_figure.py": "src/data/test_data.npz"
+                "src/scripts/test_figure.py": ["src/data/test_data.npz"]
             }
             config["run_cache_rules_on_ci"] = True
 


### PR DESCRIPTION
#### config.py

- added `expand_dependency_directories()` function that recursively finds all files in a specified directory
- modified `get_upstream_dependencies()` to expand directory dependencies into individual files before recursing

#### preprocess.py

- imported the new expand_dependency_directories() function
- updated the dependency collection logic to expand any directory dependencies into individual files

#### docs

- updated the `dependencies` section to document that dependencies can now be directories
- added an example showing how to specify a whole directory as a dependency

#### tests

- added three new integration test classes scenarios I thought might happen (`test_directory_dependencies.py`):

  - single directory containing simple helper scripts, this is the new core feature
  - script depending on multiple directories simultaneously
  - individual files and directories mixed in the same dependency list

I did not make the tests remote as I think this is more of a internal structure thing

Closes #401 