### PR TITLE
docs: add temporary banner about development version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ html_logo = "_static/logo.png"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 html_theme_options = {
+    "announcement": "The last release is 2+ years old! For the time being, please use the latest dev version. Stay tuned!",
     "repository_url": "https://github.com/showyourwork/showyourwork",
     "repository_branch": "main",
     "use_edit_page_button": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,3 +63,4 @@ autoclass_content = "both"
 autosummary_generate = True
 autodoc_docstring_signature = True
 autodoc_default_options = {"members": True}
+autodoc_mock_imports = ["pymupdf"]

--- a/docs/dev_version_banner.rst
+++ b/docs/dev_version_banner.rst
@@ -1,0 +1,7 @@
+.. important::
+
+    A lot of time passed since the last release: there have been many important changes
+    to the codebase and a change in the active team of maintainers.
+
+    We are working hard for a new release soon!
+    Until then we strongly suggest you to use the latest development version.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,28 +1,30 @@
+.. _install:
+
 Installation
 ============
 
-Install the latest version using `pip <https://pypi.org/project/pip/>`_:
+| In order to use |showyourwork|, you'll also need a working installation of the *conda* package manager.
+| We recommend using `miniforge <https://conda-forge.org/download/>`_.
+
+Create a new conda environment with the necessary dependencies:
 
 .. code-block:: bash
 
-    pip install -U showyourwork
+    mamba create -n showyourwork pip
+    mamba activate showyourwork
 
-Note that in order to use |showyourwork|, you'll also need a working installation
-of the `conda package manager <https://docs.continuum.io/anaconda/install/>`_.
+.. include:: dev_version_banner.rst
 
-You can also install the latest development version from GitHub:
+.. tab-set::
 
-.. code-block:: bash
+    .. tab-item:: Latest release
 
-    pip install git+https://github.com/showyourwork/showyourwork
+        .. code-block:: bash
 
-.. note::
+            pip install showyourwork
 
-    |showyourwork| is constantly under development, so users should upgrade
-    frequently (just pass the ``-U`` argument to ``pip`` as shown above).
-    Check out the latest release on
-    `PyPI <https://pypi.python.org/pypi/showyourwork>`__ and read the release
-    notes at :doc:`changelog`.
+    .. tab-item:: Development version
 
-    See :ref:`known_issues` for a list of issues known by the developers,
-    but which have not yet been fixed in a stable release.
+        .. code-block:: bash
+
+            pip install git+https://github.com/showyourwork/showyourwork

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -71,7 +71,7 @@ to use the latest unreleased version of the action:
           OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
 
 `KeyError: 'tex_files_out' (#400) <https://github.com/showyourwork/showyourwork/issues/400>`_
------------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------
 
 .. important::
 
@@ -84,7 +84,7 @@ Please comment line 405 in
 .. _frozen_cache_bug:
 
 `No new Zenodo drafts created after freezing cache #638 <https://github.com/showyourwork/showyourwork/issues/638>`_
------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------
 
 Once the Zenodo cache is frozen, no new Zenodo drafts are created by |showyourwork|.
 As a workaround while we work on a solution, we recommend users do not freeze the cache until it is ready to be published.

--- a/docs/quickbuild.rst
+++ b/docs/quickbuild.rst
@@ -3,13 +3,9 @@
    Find an open source article you'd like to reproduce or tinker with?
    Build it in 3 easy steps.
 
-   1. Install the latest version of |showyourwork|:
+   1. :ref:`Install <install>` |showyourwork|:
 
       .. include:: dev_version_banner.rst
-
-      .. code-block:: bash
-
-         pip install -U showyourwork
 
       .. raw:: html
 

--- a/docs/quickbuild.rst
+++ b/docs/quickbuild.rst
@@ -5,6 +5,8 @@
 
    1. Install the latest version of |showyourwork|:
 
+      .. include:: dev_version_banner.rst
+
       .. code-block:: bash
 
          pip install -U showyourwork

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,26 +1,6 @@
 Quickstart
 ==========
 
-Requirements
-------------
-
-You'll need to have the ``conda`` package manager installed, which you
-can download from `this url <https://www.anaconda.com/products/distribution>`_.
-
-Install
--------
-
-To get started with |showyourwork|, install the latest version using the ``pip`` command:
-
-.. include:: dev_version_banner.rst
-
-.. code-block:: bash
-
-    pip install -U showyourwork
-
-
-
-
 Setup a new article
 -------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,23 +1,24 @@
 Quickstart
 ==========
 
-.. important::
+Requirements
+------------
 
-    A known issue until the next release requires to use the latest version of showyourwork
-    so the use of the latest version is recommended both locally and on the remote.
-    For the latter, please run the setup command with the option ``-a git+https://github.com/showyourwork/showyourwork``.
+You'll need to have the ``conda`` package manager installed, which you
+can download from `this url <https://www.anaconda.com/products/distribution>`_.
 
 Install
 -------
 
 To get started with |showyourwork|, install the latest version using the ``pip`` command:
 
+.. include:: dev_version_banner.rst
+
 .. code-block:: bash
 
     pip install -U showyourwork
 
-You'll also need to have the ``conda`` package manager installed, which you
-can download from `this url <https://www.anaconda.com/products/distribution>`_.
+
 
 
 Setup a new article

--- a/docs/snakefile.rst
+++ b/docs/snakefile.rst
@@ -1,6 +1,8 @@
 Intro to Snakemake
 ==================
 
+.. _rules: https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html
+
 Under the hood, |showyourwork| is essentially a wrapper around Snakemake. The
 code builds the article PDF by parsing the ``showyourwork.yml`` config file and
 the ``ms.tex`` manuscript to build the computational graph for the workflow,
@@ -23,8 +25,7 @@ Every ``showyourwork`` article repository is instantiated with a blank Snakefile
 at the repository root. This file gets included at the start of the main (build) step of the
 workflow, and may thus be used to define custom rules or to run custom ``python``
 code during the workflow. Almost everything you need to know about Snakefiles can
-be found in the
-`Snakemake documentation <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html>`_,
+be found in the Snakemake documentation about `rules`_,
 but we'll go over the basics below.
 
 Snakefiles are, at their core, Python scripts with a little extra functionality.
@@ -88,8 +89,7 @@ There are a lot of other features supported within rules; for instance,
 input files and parameters can be provided as *functions*, adding another
 layer of flexibility to your workflow. Rules can also be declared within
 for loops, if statements, etc. For the full list of features, please refer
-to the
-`Snakemake documentation <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html>`_.
+to the `rules`_.
 
 
 Intermediate results
@@ -204,7 +204,6 @@ When starting up a project or when in a rapid development phase, it can be usefu
 tell Snakemake to ignore changes to a file or timestamp when running the build. For
 example, you may have a slow rule to generate a data file from querying an external data
 archive and you just want to use a temporary subset of the data or existing copy of the
-data. Snakemake supports this with the ``ancient()`` command. See the `Snakemake
-documentation
-<https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ignoring-timestamps>`_
+data. Snakemake supports this with the ``ancient()`` command.
+See the `how to ignore timestamps <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ignoring-timestamps>`_
 for more information about how to use this in a rule.


### PR DESCRIPTION
We are getting close to the next release (see #563)!

Until then I want to make sure new users as well as old aficionados know that a LOT has happened since the last release (more than 2 years ago!) and that the development version is actively maintained.

I took advantage of this to:

- simplify the installation instructions
- use [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/index.html) tabs to make it more compact
- fix a couple of documentation build warnings

You can peek at the new version of the docs from [here](https://showyourwork--673.org.readthedocs.build/en/673/).

