### PR TITLE
Unpin chardet now that binaryornot fixed the issue upstream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "requests",
     "click",
     "cookiecutter",
-    "chardet>=5.0.0,<7.0.0", # see https://github.com/cookiecutter/cookiecutter/pull/2196
     "packaging",
     "snakemake",
     "pulp",

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -1,0 +1,22 @@
+import sys
+
+import pytest
+
+
+def test_requests_import_no_dependency_warning():
+    """Test that importing requests doesn't produce RequestsDependencyWarning."""
+    # Remove requests from sys.modules to force reimport
+    modules_to_remove = [key for key in sys.modules if key.startswith("requests")]
+    for module in modules_to_remove:
+        del sys.modules[module]
+
+    # Use pytest's warning recorder to capture all warnings
+    with pytest.warns() as warning_list:
+        import requests  # noqa: F401
+
+    # Check if any RequestsDependencyWarning was raised
+    for warning in warning_list:
+        if "RequestsDependencyWarning" in str(warning.category):
+            pytest.fail(f"RequestsDependencyWarning detected: {warning.message}")
+        if "RequestsDependencyWarning" in str(warning.message):
+            pytest.fail(f"RequestsDependencyWarning detected: {warning.message}")

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import pytest
 
@@ -10,8 +11,9 @@ def test_requests_import_no_dependency_warning():
     for module in modules_to_remove:
         del sys.modules[module]
 
-    # Use pytest's warning recorder to capture all warnings
-    with pytest.warns() as warning_list:
+    # Use warnings.catch_warnings to capture all warnings
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
         import requests  # noqa: F401
 
     # Check if any RequestsDependencyWarning was raised


### PR DESCRIPTION
Based on [the latest binaryornot releases](https://github.com/binaryornot/binaryornot/releases), the issue with chardet is fixed (I think in 0.6.0 chardet is no longer used at all). This means we can unpin `chardet` on our end.

I tested `test_default.py` with `binaryornot==0.4.4` to confirm the tests were failing, then with `binaryornot==0.6.0` to confirm the issue was gone.

I also added an import test to make sure the weird `requests` dependency warning was gone.