### PR TITLE
Add the possibility to let the output through when debugging integration tests

### DIFF
--- a/docs/integration_tests.rst
+++ b/docs/integration_tests.rst
@@ -96,6 +96,18 @@ the output from the Python script.
 That's it! The parent class (``TemporaryShowyourworkRepository``) takes care
 of the rest.
 
+Debugging within the tests
+--------------------------
+
+By default, the integration tests capture the output when running the ``showyourwork`` command.
+This will cause problems when trying to debug parts of the main ``showyourwork`` code within the tests.
+To do so, you will need to enable debug mode to let the output pass through:
+
+.. code-block:: bash
+
+    DEBUG=1 python -m pytest tests/integration/test_default.py -s
+
+
 Remote tests
 ------------
 

--- a/src/showyourwork/subproc.py
+++ b/src/showyourwork/subproc.py
@@ -22,7 +22,13 @@ def process_run_result(code, stdout, stderr):
 
 
 def get_stdout(
-    args, shell=False, cwd=None, secrets=(), callback=process_run_result, env=None
+    args,
+    shell=False,
+    cwd=None,
+    secrets=(),
+    callback=process_run_result,
+    env=None,
+    capture_output=True,
 ):
     """
     A thin wrapper around ``subprocess.run`` that hides secrets and decodes
@@ -36,6 +42,9 @@ def get_stdout(
         secrets (list, optional): Secrets to be masked in the output.
         callback (callable, optional): Callback to process the result.
         env (dict): Extra environment variables to be passed to the ``subprocess.run``
+        capture_output (bool, optional): If ``True`` (default), capture ``stdout`` and
+            ``stderr`` and pass decoded strings to ``callback``. If ``False``, stream
+            command output directly to the terminal.
 
     """
     #  Update the environment variables if passed
@@ -43,14 +52,25 @@ def get_stdout(
     if env is not None:
         subprocess_env.update(env)
 
-    # Run the command and capture all output
+    # Run the command
     result = subprocess.run(
-        args, shell=shell, cwd=cwd, capture_output=True, check=False, env=subprocess_env
+        args,
+        shell=shell,
+        cwd=cwd,
+        env=subprocess_env,
+        check=False,
+        capture_output=capture_output,
     )
 
     # Parse the output
-    stdout = result.stdout.decode()
-    stderr = result.stderr.decode()
+    stdout = (
+        result.stdout.decode() if isinstance(result.stdout, bytes) else result.stdout
+    )
+    stderr = (
+        result.stderr.decode() if isinstance(result.stderr, bytes) else result.stderr
+    )
+    stdout = stdout or ""
+    stderr = stderr or ""
     code = result.returncode
 
     # Hide secrets from the command output

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -69,6 +69,11 @@ class TemporaryShowyourworkRepository:
     def cwd(self):
         return self.root_path / self.repo
 
+    def run_command(self, *args, **kwargs):
+        """Run a command, streaming output when debugging locally."""
+        kwargs.setdefault("capture_output", not self.debug)
+        return get_stdout(*args, **kwargs)
+
     def startup(self):
         """Subclass me to run things at startup."""
         pass
@@ -110,12 +115,12 @@ class TemporaryShowyourworkRepository:
 
         # Provide git name & email
         if os.getenv("CI", "false") == "true":
-            get_stdout(
+            self.run_command(
                 'git config --global user.name "gh-actions"',
                 cwd=self.root_path,
                 shell=True,
             )
-            get_stdout(
+            self.run_command(
                 'git config --global user.email "gh-actions"',
                 cwd=self.root_path,
                 shell=True,
@@ -123,7 +128,7 @@ class TemporaryShowyourworkRepository:
 
         # Create a new one
         print(f"[{self.repo}] Creating local repo `tests/sandbox/{self.repo}`...")
-        get_stdout(
+        self.run_command(
             f"{command} {options} {GITHUB_USER}/{self.repo}",
             cwd=self.root_path,
             shell=True,
@@ -175,8 +180,8 @@ class TemporaryShowyourworkRepository:
 
     def git_commit(self):
         """Add and commit all files in the local repo."""
-        get_stdout("git add .", shell=True, cwd=self.cwd)
-        get_stdout(
+        self.run_command("git add .", shell=True, cwd=self.cwd)
+        self.run_command(
             "git diff-index --quiet HEAD || "
             'git -c user.name="gh-actions" -c user.email="gh-actions" '
             'commit -q -m "auto commit from showyourwork tests"',
@@ -198,7 +203,7 @@ class TemporaryShowyourworkRepository:
         args = ""
         if self.dry_run:
             args += " --dry-run"
-        get_stdout(
+        self.run_command(
             "showyourwork build" + args,
             shell=True,
             cwd=self.cwd,
@@ -215,7 +220,7 @@ class TemporaryShowyourworkRepository:
 
         """
         print(f"[{self.repo}] Pushing to `{GITHUB_USER}/{self.repo}`...")
-        get_stdout(
+        self.run_command(
             "git push --force https://x-access-token:"
             f"{gitapi.get_access_token()}"
             f"@github.com/{GITHUB_USER}/{self.repo} main",
@@ -223,9 +228,9 @@ class TemporaryShowyourworkRepository:
             cwd=self.cwd,
             secrets=[gitapi.get_access_token()],
         )
-        head_sha = get_stdout("git rev-parse HEAD", shell=True, cwd=self.cwd).replace(
-            "\n", ""
-        )
+        head_sha = self.run_command(
+            "git rev-parse HEAD", shell=True, cwd=self.cwd
+        ).replace("\n", "")
         print(
             f"[{self.repo}] Waiting {self.action_wait} seconds for workflow "
             f"to finish (1/{self.action_max_tries})..."


### PR DESCRIPTION
In the integration tests, `showyourwork` is called through the `get_stdout()` function, which always calls `subprocess.run()` with `capture_output=True`. This is an issue when trying to debug `showyourwork` code with `ipdb` during the integration tests.

This PR makes `capture_output` an argument to `get_stdout()` (`True` by default) and uses the existing `self.debug` flag to determine whether the output should be captured when running the integration tests. I also added a mention of this in the integration tests docs.