### PR TITLE
Add a `showyourwork cache reserve` command to pre-reserve a DOI from the main Zenodo service

### DIFF
--- a/docs/changes/685.feature.rst
+++ b/docs/changes/685.feature.rst
@@ -1,0 +1,1 @@
+Add the ``showyourwork cache reserve`` subcommand to reserve a DOI on the main Zenodo service without publishing.

--- a/src/showyourwork/cli/commands/__init__.py
+++ b/src/showyourwork/cli/commands/__init__.py
@@ -14,4 +14,5 @@ from .zenodo import (
     zenodo_delete as zenodo_delete,
     zenodo_freeze as zenodo_freeze,
     zenodo_publish as zenodo_publish,
+    zenodo_reserve as zenodo_reserve,
 )

--- a/src/showyourwork/cli/commands/zenodo.py
+++ b/src/showyourwork/cli/commands/zenodo.py
@@ -6,6 +6,41 @@ from ...git import get_repo_branch
 from ...zenodo import Zenodo
 
 
+def zenodo_reserve(branch):
+    """Reserve a DOI on Zenodo
+
+    Reserves a permanent DOI for the deposit on the main Zenodo service.
+    This does not push any data, but pre-reserves the DOI that will later
+    be used by ``zenodo cache publish``.
+
+    Args:
+        branch (str): Branch to publish.
+    """
+    # Ensure there's a sandbox cache record for this branch
+    if branch is None:
+        branch = get_repo_branch()
+
+    # Get the Zenodo doi, or create one if needed
+    with edit_yaml("zenodo.yml") as config:
+        zenodo_doi = config["cache"].get(branch, {}).get("zenodo", None)
+    if "SANDBOX_ONLY" in os.environ:
+        # Publish to Sandbox if we're in a test run
+        service = "sandbox"
+    else:
+        service = "zenodo"
+    # TODO: This should be tested
+    if zenodo_doi is not None:
+        raise exceptions.ZenodoError(f"There is already a DOI for branch {branch}")
+
+    zenodo = Zenodo(service)
+    zenodo_doi = zenodo.doi
+
+    # Fill in the config
+    with edit_yaml("zenodo.yml") as config:
+        config["cache"][branch] = config["cache"].get(branch, {})
+        config["cache"][branch]["zenodo"] = zenodo_doi
+
+
 def zenodo_publish(branch):
     """Publish the cache.
 

--- a/src/showyourwork/cli/commands/zenodo.py
+++ b/src/showyourwork/cli/commands/zenodo.py
@@ -28,7 +28,6 @@ def zenodo_reserve(branch):
         service = "sandbox"
     else:
         service = "zenodo"
-    # TODO: This should be tested
     if zenodo_doi is not None:
         raise exceptions.ZenodoError(f"There is already a DOI for branch {branch}")
 

--- a/src/showyourwork/cli/commands/zenodo.py
+++ b/src/showyourwork/cli/commands/zenodo.py
@@ -29,7 +29,7 @@ def zenodo_reserve(branch):
     else:
         service = "zenodo"
     if zenodo_doi is not None:
-        raise exceptions.ZenodoError(f"There is already a DOI for branch {branch}")
+        raise exceptions.ExistingZenodoDOI(zenodo_doi, branch)
 
     zenodo = Zenodo(service)
     zenodo_doi = zenodo.doi

--- a/src/showyourwork/cli/main.py
+++ b/src/showyourwork/cli/main.py
@@ -415,6 +415,21 @@ def freeze(ctx, branch):
 @cache.command()
 @click.pass_context
 @click.option(*branch_option.args, **branch_option.kwargs)
+def reserve(ctx, branch):
+    """
+    Reserves a permanent, static DOI on Zenodo that can later be used by
+    ``zenodo cache publish``.
+
+    Requires a Zenodo API token provided as the environment variable
+    `ZENODO_TOKEN`.
+    """
+    ensure_top_level()
+    commands.zenodo_reserve(branch)
+
+
+@cache.command()
+@click.pass_context
+@click.option(*branch_option.args, **branch_option.kwargs)
 def publish(ctx, branch):
     """
     Publishes the current Zenodo Sandbox deposit draft for the given branch

--- a/src/showyourwork/exceptions/__init__.py
+++ b/src/showyourwork/exceptions/__init__.py
@@ -40,6 +40,7 @@ from .overleaf import (
     OverleafRateLimitExceeded as OverleafRateLimitExceeded,
 )
 from .zenodo import (
+    ExistingZenodoDOI as ExistingZenodoDOI,
     FileNotFoundOnZenodo as FileNotFoundOnZenodo,
     InvalidZenodoDOI as InvalidZenodoDOI,
     InvalidZenodoIdType as InvalidZenodoIdType,

--- a/src/showyourwork/exceptions/zenodo.py
+++ b/src/showyourwork/exceptions/zenodo.py
@@ -44,6 +44,12 @@ class InvalidZenodoDOI(ZenodoException):
         super().__init__(message)
 
 
+class ExistingZenodoDOI(ZenodoException):
+    def __init__(self, doi, branch):
+        message = f"There is already a DOI {doi} for branch {branch}"
+        super().__init__(message)
+
+
 class ZenodoUploadError(ZenodoException):
     def __init__(self):
         super().__init__("An error occurred while uploading the dataset from Zenodo.")

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -315,7 +315,7 @@ class TemporaryShowyourworkRepository:
             if isinstance(handler, logging.StreamHandler):
                 handler.setLevel(logging.ERROR)
 
-    def test_local(self):
+    def test_local(self, caplog):
         """
         Test functionality by creating a new repo, customizing it,
         pushing it to GitHub, and awaiting the article build action to
@@ -340,6 +340,9 @@ class TemporaryShowyourworkRepository:
 
             # Build the article locally
             self.build_local()
+
+            # Make captured logs available to subclasses that need them
+            self._caplog = caplog
 
             # Run local checks
             self.check_build()

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -256,6 +256,14 @@ if os.getenv("CI", "false") != "true":
             zenodo = Zenodo(zenodo_doi)
             assert zenodo.check_if_user_is_owner()
 
+            # Test that reserving with existing DOI does not modify it
+            get_stdout(
+                "SANDBOX_ONLY=true showyourwork cache reserve", cwd=self.cwd, shell=True
+            )
+            with edit_yaml(self.cwd / "zenodo.yml") as config:
+                zenodo_doi_twice = config["cache"].get("main", {}).get("zenodo", None)
+            assert zenodo_doi == zenodo_doi_twice
+
             # Make sure that no files have been uploaded
             draft = zenodo._get_draft()
             assert len(draft["files"]) == 0

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -264,14 +264,13 @@ if os.getenv("CI", "false") != "true":
 
             # Test that reserving with existing DOI raises an error
             # and leaves the DOI unchanged
-            with pytest.raises(
-                exceptions.CalledProcessError, match="There is already a DOI"
-            ):
+            with pytest.raises(exceptions.CalledProcessError):
                 get_stdout(
                     "SANDBOX_ONLY=true showyourwork cache reserve",
                     cwd=self.cwd,
                     shell=True,
                 )
+            assert "already a DOI" in self._caplog.text
             with edit_yaml(self.cwd / "zenodo.yml") as config:
                 zenodo_doi_twice = config["cache"].get("main", {}).get("zenodo", None)
             assert zenodo_doi == zenodo_doi_twice

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -8,6 +8,7 @@ from helpers import (
 
 from showyourwork.config import edit_yaml
 from showyourwork.subproc import get_stdout
+from showyourwork.zenodo import Zenodo
 
 pytestmark = pytest.mark.remote
 
@@ -208,3 +209,65 @@ if os.getenv("CI", "false") != "true":
             self.add_pipeline_script(seed=0)
             self.git_commit()
             self.build_local(env={"SYW_NO_RUN": "true"})
+
+    class TestCacheReservePublish(
+        TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
+    ):
+        """Test the Zenodo Sandbox cache publish feature."""
+
+        # Enable caching
+        cache = True
+
+        # No need to test this on CI
+        local_build_only = True
+
+        def customize(self):
+            """Add all necessary files for the build."""
+            # Add the pipeline script
+            self.add_pipeline_script(seed=0)
+
+            # Add the Snakefile rule to generate the dataset
+            self.add_pipeline_rule()
+
+            # Add the script to generate the figure
+            self.add_figure_script(load_data=True)
+
+            # Make the dataset a dependency of the figure
+            with edit_yaml(self.cwd / "showyourwork.yml") as config:
+                config["dependencies"] = {
+                    "src/scripts/test_figure.py": "src/data/test_data.npz"
+                }
+                config["run_cache_rules_on_ci"] = True
+
+            # Add the figure environment to the tex file
+            self.add_figure_environment()
+
+        def check_build(self):
+            # Reserve a DOI without publishing anything
+            # This normally creates a record *Zenodo*, but we can hack it
+            # to use Sandbox so we don't create an actual DOI every time we test!
+            get_stdout(
+                "SANDBOX_ONLY=true showyourwork cache reserve", cwd=self.cwd, shell=True
+            )
+            with edit_yaml(self.cwd / "zenodo.yml") as config:
+                zenodo_doi = config["cache"].get("main", {}).get("zenodo", None)
+            # Make sure the doi was added to the config and that the deposit exists
+            assert zenodo_doi is not None
+            zenodo = Zenodo(zenodo_doi)
+            assert zenodo.check_if_user_is_owner()
+
+            # Make sure that no files have been uploaded
+            draft = zenodo._get_draft()
+            assert len(draft["files"]) == 0
+            assert "notes" not in draft["metadata"]
+
+            # Now publish and ensure the same DOI was used and files were uploaded
+            get_stdout(
+                "SANDBOX_ONLY=true showyourwork cache publish", cwd=self.cwd, shell=True
+            )
+            with edit_yaml(self.cwd / "zenodo.yml") as config:
+                zenodo_doi_pub = config["cache"].get("main", {}).get("zenodo", None)
+            assert zenodo_doi_pub == zenodo_doi
+            # Files are uploaded
+            assert len(draft["files"]) == 0
+            assert "notes" not in draft["metadata"]

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -6,6 +6,7 @@ from helpers import (
     TemporaryShowyourworkRepository,
 )
 
+from showyourwork import exceptions
 from showyourwork.config import edit_yaml
 from showyourwork.subproc import get_stdout
 from showyourwork.zenodo import Zenodo
@@ -270,9 +271,12 @@ if os.getenv("CI", "false") != "true":
             assert "notes" not in draft["metadata"]
 
             # Now publish and ensure the same DOI was used and files were uploaded
-            get_stdout(
-                "SANDBOX_ONLY=true showyourwork cache publish", cwd=self.cwd, shell=True
-            )
+            with pytest.raises(exceptions.CalledProcessError):
+                get_stdout(
+                    "SANDBOX_ONLY=true showyourwork cache publish",
+                    cwd=self.cwd,
+                    shell=True,
+                )
             with edit_yaml(self.cwd / "zenodo.yml") as config:
                 zenodo_doi_pub = config["cache"].get("main", {}).get("zenodo", None)
             assert zenodo_doi_pub == zenodo_doi

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -257,26 +257,29 @@ if os.getenv("CI", "false") != "true":
             zenodo = Zenodo(zenodo_doi)
             assert zenodo.check_if_user_is_owner()
 
-            # Test that reserving with existing DOI does not modify it
-            get_stdout(
-                "SANDBOX_ONLY=true showyourwork cache reserve", cwd=self.cwd, shell=True
-            )
-            with edit_yaml(self.cwd / "zenodo.yml") as config:
-                zenodo_doi_twice = config["cache"].get("main", {}).get("zenodo", None)
-            assert zenodo_doi == zenodo_doi_twice
-
             # Make sure that no files have been uploaded
             draft = zenodo._get_draft()
             assert len(draft["files"]) == 0
             assert "notes" not in draft["metadata"]
 
-            # Now publish and ensure the same DOI was used and files were uploaded
-            with pytest.raises(exceptions.CalledProcessError):
+            # Test that reserving with existing DOI raises an error
+            # and leaves the DOI unchanged
+            with pytest.raises(
+                exceptions.CalledProcessError, match="There is already a DOI"
+            ):
                 get_stdout(
-                    "SANDBOX_ONLY=true showyourwork cache publish",
+                    "SANDBOX_ONLY=true showyourwork cache reserve",
                     cwd=self.cwd,
                     shell=True,
                 )
+            with edit_yaml(self.cwd / "zenodo.yml") as config:
+                zenodo_doi_twice = config["cache"].get("main", {}).get("zenodo", None)
+            assert zenodo_doi == zenodo_doi_twice
+
+            # Now publish and ensure the same DOI was used and files were uploaded
+            get_stdout(
+                "SANDBOX_ONLY=true showyourwork cache publish", cwd=self.cwd, shell=True
+            )
             with edit_yaml(self.cwd / "zenodo.yml") as config:
                 zenodo_doi_pub = config["cache"].get("main", {}).get("zenodo", None)
             assert zenodo_doi_pub == zenodo_doi


### PR DESCRIPTION
This PR adds a `showyourwork cache reserve` command which will create a draft on the main zenodo.org service without pushing anything to it, and register the DOI in `zenodo.yaml`.

Then, the `showyourwork cache publish` command will use this existing DOI from the config file.

If a DOI already exists, an error is raised to avoid any ambiguity.

Fixes #402.

Marking as draft for now as I need to add tests.