### PR TITLE
Patch snakemake's `onsuccess` hook to include the one from `build.smk` in addition to user's

### DIFF
--- a/docs/changes/688.feature.rst
+++ b/docs/changes/688.feature.rst
@@ -1,0 +1,2 @@
+Ensure that ``onstart``, ``onsuccess`` and ``onerror`` hook directives created by the user
+get executed normally with Snakemake by merging with showyourwork's internal hooks.

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -17,7 +17,6 @@ from functools import partial
 from pathlib import Path
 
 from snakemake.caching.local import OutputFileCache as LocalOutputFileCache
-from snakemake.workflow import Workflow
 
 from . import exceptions, paths
 from .logging import ColorizingStreamHandler, get_logger
@@ -102,6 +101,7 @@ def get_snakemake_variable(name, default=None):
 
 
 def patch_snakemake_onsuccess():
+    from snakemake.workflow import Workflow
 
     _onsuccess = Workflow.onsuccess
 

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -14,6 +14,7 @@ import os
 import time
 import types
 from functools import partial
+from pathlib import Path
 
 from snakemake.caching.local import OutputFileCache as LocalOutputFileCache
 from snakemake.workflow import Workflow
@@ -107,10 +108,16 @@ def patch_snakemake_onsuccess():
     def onsuccess(self, func):
         """Register onsuccess function."""
 
+        # For all user files, process normally with snakemake
+        source_file = Path(inspect.getsourcefile(func))
+        if source_file.name != "build.smk":
+            _onsuccess(self, func)
+            return
+
+        # When we reach build.smk, preserve user's latest onsuccess
+        # and merge it with the one from build.smk
         old_onsuccess = self._onsuccess
 
-        # TODO: Could we be more selective on which old functions we keep?
-        # Inspect and ensure they are from user's snaekefile or build.smk
         def _new_onsuccess(log):
             old_onsuccess(log)
             func(log)

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -16,6 +16,7 @@ import types
 from functools import partial
 
 from snakemake.caching.local import OutputFileCache as LocalOutputFileCache
+from snakemake.workflow import Workflow
 
 from . import exceptions, paths
 from .logging import ColorizingStreamHandler, get_logger
@@ -97,6 +98,30 @@ def get_snakemake_variable(name, default=None):
         if value is not None:
             return value
     return default
+
+
+def patch_snakemake_onsuccess():
+
+    _onsuccess = Workflow.onsuccess
+
+    def onsuccess(self, func):
+        """Register onsuccess function."""
+
+        old_onsuccess = self._onsuccess
+
+        # TODO: Could we be more selective on which old functions we keep?
+        # Inspect and ensure they are from user's snaekefile or build.smk
+        def _new_onsuccess(log):
+            old_onsuccess(log)
+            func(log)
+
+        if self.modifier.is_main_snakefile():
+            self._onsuccess = _new_onsuccess
+        self.globals["onsuccess"] = partial(
+            _new_onsuccess, log=self.logger_manager.get_logfile()
+        )
+
+    Workflow.onsuccess = onsuccess
 
 
 def patch_snakemake_cache(zenodo_doi, sandbox_doi):

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -100,10 +100,21 @@ def get_snakemake_variable(name, default=None):
     return default
 
 
-def patch_snakemake_onsuccess():
+def patch_snakemake_hooks():
+    """
+    Patches the Snakemake onsuccess, onerror and onstart to
+
+    - Process all user hook directives using snakemake's default behaviour
+    - Merge the user rule with showyourwork's hook directives
+    - onerror and onsuccess run the user's directive first and then showyourwork's
+    - onstart runs showyourk's rule first and then the user's
+    """
+
     from snakemake.workflow import Workflow
 
     _onsuccess = Workflow.onsuccess
+    _onerror = Workflow.onerror
+    _onstart = Workflow.onstart
 
     def onsuccess(self, func):
         """Register onsuccess function."""
@@ -128,7 +139,55 @@ def patch_snakemake_onsuccess():
             _new_onsuccess, log=self.logger_manager.get_logfile()
         )
 
+    def onerror(self, func):
+        """Register onerror function."""
+
+        # For all user files, process normally with snakemake
+        source_file = Path(inspect.getsourcefile(func))
+        if source_file.name != "build.smk":
+            _onerror(self, func)
+            return
+
+        # When we reach build.smk, preserve user's latest onerror
+        # and merge it with the one from build.smk
+        old_onerror = self._onerror
+
+        def _new_onerror(log):
+            old_onerror(log)
+            func(log)
+
+        if self.modifier.is_main_snakefile():
+            self._onerror = _new_onerror
+        self.globals["onerror"] = partial(
+            _new_onerror, log=self.logger_manager.get_logfile()
+        )
+
+    def onstart(self, func):
+        """Register onstart function."""
+
+        # For all user files, process normally with snakemake
+        source_file = Path(inspect.getsourcefile(func))
+        if source_file.name != "build.smk":
+            _onstart(self, func)
+            return
+
+        # When we reach build.smk, preserve user's latest onstart
+        # and merge it with the one from build.smk
+        old_onstart = self._onstart
+
+        def _new_onstart(log):
+            func(log)
+            old_onstart(log)
+
+        if self.modifier.is_main_snakefile():
+            self._onstart = _new_onstart
+        self.globals["onstart"] = partial(
+            _new_onstart, log=self.logger_manager.get_logfile()
+        )
+
     Workflow.onsuccess = onsuccess
+    Workflow.onerror = onerror
+    Workflow.onstart = onstart
 
 
 def patch_snakemake_cache(zenodo_doi, sandbox_doi):

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -7,7 +7,7 @@ from showyourwork import paths, exceptions, overleaf
 from showyourwork.patches import (
     patch_snakemake_wait_for_files,
     patch_snakemake_logging,
-    patch_snakemake_onsuccess,
+    patch_snakemake_hooks,
     patch_snakemake_missing_input_leniency,
 )
 from showyourwork.config import parse_config, get_run_type
@@ -44,9 +44,11 @@ else:
     for file in paths.user().flags.glob("*"):
         file.unlink()
 
-        # Set up custom logging for Snakemake
+    # Set up custom logging for Snakemake
     patch_snakemake_logging()
-    patch_snakemake_onsuccess()
+
+    # Patch snakemake onstart, onerror and onsuccess (merge syw and user)
+    patch_snakemake_hooks()
 
     # Parse the config file
     parse_config()

--- a/src/showyourwork/workflow/build.smk
+++ b/src/showyourwork/workflow/build.smk
@@ -7,6 +7,7 @@ from showyourwork import paths, exceptions, overleaf
 from showyourwork.patches import (
     patch_snakemake_wait_for_files,
     patch_snakemake_logging,
+    patch_snakemake_onsuccess,
     patch_snakemake_missing_input_leniency,
 )
 from showyourwork.config import parse_config, get_run_type
@@ -45,6 +46,7 @@ else:
 
         # Set up custom logging for Snakemake
     patch_snakemake_logging()
+    patch_snakemake_onsuccess()
 
     # Parse the config file
     parse_config()

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -68,6 +68,7 @@ class TestHooksError(TestHooks):
     """
 
     hooks = ["onstart", "onerror"]
+    local_build_only = True
 
     def customize(self):
         super().customize()

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -1,0 +1,79 @@
+import pytest
+from helpers import (
+    ShowyourworkRepositoryActions,
+    TemporaryShowyourworkRepository,
+)
+
+from showyourwork.config import edit_yaml
+
+
+class TestHooks(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """
+    Test the showyourwork patches to snakemake's onstart and onsuccess hooks.
+    """
+
+    hooks = ["onstart", "onsuccess"]
+
+    def add_hook(self, name):
+        with open(self.cwd / "Snakefile", "a") as f:
+            print("\n", file=f)
+            print(
+                "\n".join(
+                    [
+                        f"{name}:",
+                        f"    with open('{name}.txt', 'w') as f:",
+                        f"        f.write('{name}\\n')",
+                    ]
+                ),
+                file=f,
+            )
+            print("\n", file=f)
+
+    def add_hooks(self):
+        for hook in self.hooks:
+            self.add_hook(hook)
+
+    def customize(self):
+
+        # Add the pipeline script
+        self.add_pipeline_script()
+
+        # Add the Snakefile rule to generate the dataset
+        self.add_pipeline_rule()
+        self.add_hooks()
+
+        # Add the script to generate the figure
+        self.add_figure_script(load_data=True)
+
+        # Make the dataset a dependency of the figure
+        with edit_yaml(self.cwd / "showyourwork.yml") as config:
+            config["dependencies"] = {
+                "src/scripts/test_figure.py": "src/data/test_data.npz"
+            }
+            config["run_cache_rules_on_ci"] = True
+
+        # Add the figure environment to the tex file
+        self.add_figure_environment()
+
+    def check_build(self):
+        for hook in self.hooks:
+            hook_file = self.cwd / f"{hook}.txt"
+            assert hook_file.is_file()
+            assert hook_file.read_text() == f"{hook}\n"
+
+
+class TestHooksError(TestHooks):
+    """
+    Test the showyourwork patches to snakemake's onstart and onerror hooks.
+    """
+
+    hooks = ["onstart", "onerror"]
+
+    def customize(self):
+        super().customize()
+        with open(self.cwd / "src" / "scripts" / "test_data.py", "a") as f:
+            print("\nraise RuntimeError('there was an error')\n", file=f)
+
+    def build_local(self, env=None):
+        with pytest.raises(Exception, match="there was an error"):
+            super().build_local(env=env)


### PR DESCRIPTION
By default, snakemake will process all `onsuccess` directives but keep only the last one encountered. In showyourwork, this means the only `onsuccess` kept is the one from `build.smk`, and it will overwrite the one from the user's snakefile. This can be suprising since users don't necessarily know about the internal and can expect the `onsuccess` to work normally, as `onerror` and `onstart` already do.

This PR patches the `onsuccess` hook so that:

- All user rules and files are processed as usual, so that only the last encountered user-defined `onsuccess` is kept. This is consistent with Snakemake
- When we reach `build.smk`, merge the latest user-defined hook with the one from `build.smk`

**Questions/TODO**:

- [x] Currently, `build.smk` only defines an `onsuccess`. Should we also patch `onerror` and `onstart` in case they are used in the future?
- [x] Should we handle not only `build.smk` but all smk files defined within snakemake in case the hook is moved to a different location?
- [x] I still need to write integration tests for this, but it works on a small test repo I did.
- [x] I also need to fix the unit tests

Fixes #629.