### PR TITLE
Support targets in `showyourwork build`

### DIFF
--- a/docs/changes/690.feature.rst
+++ b/docs/changes/690.feature.rst
@@ -1,0 +1,4 @@
+Adds support for snakemake targets with `showyourwork build`.
+For example, `showyourwork build myrule` will now execute only up to `myrule`
+and `showyourwork build src/data/myfile.txt` will now execute only the rules required to generate `myfile.txt`.
+This is equivalent to `snakemake myrule`.

--- a/src/showyourwork/cli/commands/preprocess.py
+++ b/src/showyourwork/cli/commands/preprocess.py
@@ -1,3 +1,5 @@
+from snakemake.cli import parse_args
+
 from ... import paths
 from .run_snakemake import run_snakemake
 
@@ -12,11 +14,16 @@ def preprocess(snakemake_args=(), cores=1, conda_frontend="conda"):
         arg for arg in snakemake_args if arg not in ["--dry-run", "-n"]
     )
     snakefile = paths.showyourwork().workflow / "prep.smk"
+    target_args = parse_args(snakemake_args)[1].targets
+    snakemake_args_notargets = []
+    for arg in snakemake_args:
+        if arg not in target_args:
+            snakemake_args_notargets.append(arg)
     run_snakemake(
         snakefile.as_posix(),
         run_type="preprocess",
         cores=cores,
         conda_frontend=conda_frontend,
-        extra_args=snakemake_args,
+        extra_args=snakemake_args_notargets,
         check=True,
     )

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -51,7 +51,6 @@ class TemporaryShowyourworkRepository:
     require_local_build = False
     delete_remote_on_success = False
     clear_actions_cache_on_start = True
-    dry_run = False
 
     # Internal
     _sandbox_concept_doi = None
@@ -189,7 +188,7 @@ class TemporaryShowyourworkRepository:
             cwd=self.cwd,
         )
 
-    def build_local(self, env=None):
+    def build_local(self, env=None, args=None):
         """Run showyourwork locally to build the article."""
         print(f"[{self.repo}] Building the article locally...")
 
@@ -200,11 +199,12 @@ class TemporaryShowyourworkRepository:
         env_var = {"CI": "false"}
         if env is not None:
             env_var.update(env)
-        args = ""
-        if self.dry_run:
-            args += " --dry-run"
+        if args is None:
+            args = ""
+        else:
+            args = " ".join(args)
         self.run_command(
-            "showyourwork build" + args,
+            "showyourwork build " + args,
             shell=True,
             cwd=self.cwd,
             env=env_var,

--- a/tests/integration/test_default.py
+++ b/tests/integration/test_default.py
@@ -10,4 +10,5 @@ class TestDefault(TemporaryShowyourworkRepository):
 class TestDefaultDry(TemporaryShowyourworkRepository):
     """Test setting up and building the default repo with a dry-run"""
 
-    dry_run = True
+    def build_local(self):
+        super().build_local(args=["--dry-run"])

--- a/tests/integration/test_target.py
+++ b/tests/integration/test_target.py
@@ -1,7 +1,8 @@
 from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
 
 
-class TestTarget(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+# TODO: Add assertions that the output files exist
+class TestTargetRule(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
     """The setting up and building the repo with target rule"""
 
     def customize(self):
@@ -11,3 +12,44 @@ class TestTarget(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions)
 
     def build_local(self):
         super().build_local(args=["generate_data"])
+
+
+class TestTargetFile(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """The setting up and building the repo with target rule"""
+
+    def customize(self):
+        self.add_pipeline_script()
+
+        self.add_pipeline_rule()
+
+    def build_local(self):
+        super().build_local(args=["src/data/test_data.npz"])
+
+
+class TestTargetMulti(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """The setting up and building the repo with target rule"""
+
+    def customize(self):
+        self.add_pipeline_script()
+
+        self.add_pipeline_rule()
+
+        with open(self.cwd / "Snakefile", "a") as f:
+            print("\n", file=f)
+            print(
+                "\n".join(
+                    [
+                        "rule touchfile:",
+                        "    output:",
+                        "        'src/data/afile.txt'",
+                        "    shell:",
+                        "        '''",
+                        "        touch {output}",
+                        "        '''",
+                    ]
+                ),
+                file=f,
+            )
+
+    def build_local(self):
+        super().build_local(args=["generate_data", "touchfile"])

--- a/tests/integration/test_target.py
+++ b/tests/integration/test_target.py
@@ -1,0 +1,13 @@
+from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
+
+
+class TestTarget(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """The setting up and building the repo with target rule"""
+
+    def customize(self):
+        self.add_pipeline_script()
+
+        self.add_pipeline_rule()
+
+    def build_local(self):
+        super().build_local(args=["generate_data"])

--- a/tests/integration/test_target.py
+++ b/tests/integration/test_target.py
@@ -13,6 +13,9 @@ class TestTargetRule(TemporaryShowyourworkRepository, ShowyourworkRepositoryActi
     def build_local(self):
         super().build_local(args=["generate_data"])
 
+    def check_build(self):
+        assert (self.cwd / "src/data/test_data.npz").is_file()
+
 
 class TestTargetFile(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
     """The setting up and building the repo with target rule"""
@@ -24,6 +27,9 @@ class TestTargetFile(TemporaryShowyourworkRepository, ShowyourworkRepositoryActi
 
     def build_local(self):
         super().build_local(args=["src/data/test_data.npz"])
+
+    def check_build(self):
+        assert (self.cwd / "src/data/test_data.npz").is_file()
 
 
 class TestTargetMulti(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
@@ -53,3 +59,7 @@ class TestTargetMulti(TemporaryShowyourworkRepository, ShowyourworkRepositoryAct
 
     def build_local(self):
         super().build_local(args=["generate_data", "touchfile"])
+
+    def check_build(self):
+        assert (self.cwd / "src/data/test_data.npz").is_file()
+        assert (self.cwd / "src/data/afile.txt").is_file()


### PR DESCRIPTION
With snakemake, it is possible to specify a target rule or output file to dictate what rule will be executed instead of the default one (at top of the snakefile).

In `showyourwork`, the default rule is `compile`, and since all extra arguments are passed to snakemake it should be possible to override it. Currently this fails due to the preprocess step.

However, the preprocess step does not know about the user rules and should not be affected by these arguments.

This PR removes target rules from the `preprocess` arguments.