### PR TITLE
Add a `--no-conda` CLI flag to run `build` and `tarball` without creating Conda environments

### DIFF
--- a/docs/changes/693.feature.rst
+++ b/docs/changes/693.feature.rst
@@ -1,0 +1,3 @@
+Adds a `--no-conda` flag to the `showyourwork build` and `showyourwork tarball` commands.
+These commands skip the creation of isolated conda environments for the the tex compilation and figure generation.
+Users are expected to have a working Python environment and tectonic installation when using this flag.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,6 +6,14 @@ Installation
 | In order to use |showyourwork|, you'll also need a working installation of the *conda* package manager.
 | We recommend using `miniforge <https://conda-forge.org/download/>`_.
 
+.. note::
+    It is possible to run Snakemake without conda or mamba by
+    passing the ``--no-conda`` flag (see :doc:`Command Line Interface <cli>`).
+    However, we recommend using conda whenever possible to improve reproduciblity.
+    When using showyourwork without conda, you must run it from an environment with
+    all required software dependencies and a working
+    `Tectonic installation <https://tectonic-typesetting.github.io>`_.
+
 Create a new conda environment with the necessary dependencies:
 
 .. code-block:: bash

--- a/src/showyourwork/cli/commands/build.py
+++ b/src/showyourwork/cli/commands/build.py
@@ -2,7 +2,7 @@ from ... import paths
 from .run_snakemake import run_snakemake
 
 
-def build(snakemake_args=(), cores=1, conda_frontend="conda"):
+def build(snakemake_args=(), cores=1, conda_frontend="conda", use_conda=True):
     """Build the article.
 
     This function builds the article PDF by running ``Snakemake`` in an isolated
@@ -20,4 +20,5 @@ def build(snakemake_args=(), cores=1, conda_frontend="conda"):
         conda_frontend=conda_frontend,
         extra_args=snakemake_args,
         check=True,
+        use_conda=use_conda,
     )

--- a/src/showyourwork/cli/commands/preprocess.py
+++ b/src/showyourwork/cli/commands/preprocess.py
@@ -4,7 +4,7 @@ from ... import paths
 from .run_snakemake import run_snakemake
 
 
-def preprocess(snakemake_args=(), cores=1, conda_frontend="conda"):
+def preprocess(snakemake_args=(), cores=1, conda_frontend="conda", use_conda=True):
     """Pre-processing step for the article build.
 
     Args:
@@ -26,4 +26,5 @@ def preprocess(snakemake_args=(), cores=1, conda_frontend="conda"):
         conda_frontend=conda_frontend,
         extra_args=snakemake_args_notargets,
         check=True,
+        use_conda=use_conda,
     )

--- a/src/showyourwork/cli/commands/run_snakemake.py
+++ b/src/showyourwork/cli/commands/run_snakemake.py
@@ -12,18 +12,24 @@ def run_snakemake(
     conda_frontend="conda",
     extra_args=(),
     check=True,
+    use_conda=True,
 ):
     env = dict(os.environ)
     env["SNAKEMAKE_OUTPUT_CACHE"] = paths.user().cache.as_posix()
     if run_type is not None:
         env["SNAKEMAKE_RUN_TYPE"] = run_type
+    conda_args = []
+    if use_conda:
+        conda_args += [
+            "--use-conda",
+            "--conda-frontend",
+            conda_frontend,
+        ]
     cmd = [
         "snakemake",
         "--cores",
         f"{cores}",
-        "--use-conda",
-        "--conda-frontend",
-        conda_frontend,
+        *conda_args,
         "--cache",
         "-s",
         snakefile,

--- a/src/showyourwork/cli/commands/tarball.py
+++ b/src/showyourwork/cli/commands/tarball.py
@@ -2,7 +2,7 @@ from ... import paths
 from .run_snakemake import run_snakemake
 
 
-def tarball(snakemake_args=(), cores=1, conda_frontend="conda"):
+def tarball(snakemake_args=(), cores=1, conda_frontend="conda", use_conda=True):
     """Build the article tarball.
 
     Args:
@@ -16,4 +16,5 @@ def tarball(snakemake_args=(), cores=1, conda_frontend="conda"):
         conda_frontend=conda_frontend,
         extra_args=list(snakemake_args) + ["syw__arxiv_entrypoint"],
         check=True,
+        use_conda=use_conda,
     )

--- a/src/showyourwork/cli/main.py
+++ b/src/showyourwork/cli/main.py
@@ -31,6 +31,14 @@ conda_frontend_option = option_spec(
         help="The conda frontend to use; passed to snakemake.",
     ),
 )
+no_conda_option = option_spec(
+    args=["--no-conda"],
+    kwargs=dict(
+        is_flag=True,
+        help="Do not use conda environments with rules. "
+        "Fall back to the current virtual environment",
+    ),
+)
 project_option = option_spec(
     args=["-p", "--project"],
     kwargs=dict(
@@ -135,10 +143,11 @@ def main():
 
 @main_command
 @click.option(*cores_option.args, **cores_option.kwargs)
+@click.option(*no_conda_option.args, **no_conda_option.kwargs)
 @click.option(*conda_frontend_option.args, **conda_frontend_option.kwargs)
 @click.option(*project_option.args, **project_option.kwargs)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
-def build(cores, conda_frontend, project, snakemake_args):
+def build(cores, no_conda, conda_frontend, project, snakemake_args):
     """Build an article in the current working directory."""
     with cwd_as(project):
         ensure_top_level()
@@ -146,11 +155,13 @@ def build(cores, conda_frontend, project, snakemake_args):
             snakemake_args=snakemake_args,
             cores=cores,
             conda_frontend=conda_frontend,
+            use_conda=not no_conda,
         )
         commands.build(
             snakemake_args=snakemake_args,
             cores=cores,
             conda_frontend=conda_frontend,
+            use_conda=not no_conda,
         )
 
 
@@ -338,10 +349,11 @@ def clean(cores, conda_frontend, project, force, deep, snakemake_args):
 
 @main_command
 @click.option(*cores_option.args, **cores_option.kwargs)
+@click.option(*no_conda_option.args, **no_conda_option.kwargs)
 @click.option(*conda_frontend_option.args, **conda_frontend_option.kwargs)
 @click.option(*project_option.args, **project_option.kwargs)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
-def tarball(cores, conda_frontend, project, snakemake_args):
+def tarball(cores, no_conda, conda_frontend, project, snakemake_args):
     """Generate a tarball of the build in the current working directory."""
     with cwd_as(project):
         ensure_top_level()
@@ -349,11 +361,13 @@ def tarball(cores, conda_frontend, project, snakemake_args):
             snakemake_args=snakemake_args,
             cores=cores,
             conda_frontend=conda_frontend,
+            use_conda=not no_conda,
         )
         commands.tarball(
             snakemake_args=snakemake_args,
             cores=cores,
             conda_frontend=conda_frontend,
+            use_conda=not no_conda,
         )
 
 

--- a/tests/integration/helpers/temp_repo.py
+++ b/tests/integration/helpers/temp_repo.py
@@ -315,7 +315,7 @@ class TemporaryShowyourworkRepository:
             if isinstance(handler, logging.StreamHandler):
                 handler.setLevel(logging.ERROR)
 
-    def test_local(self):
+    def test_local(self, caplog):
         """
         Test functionality by creating a new repo, customizing it,
         pushing it to GitHub, and awaiting the article build action to
@@ -340,6 +340,9 @@ class TemporaryShowyourworkRepository:
 
             # Build the article locally
             self.build_local()
+
+            # Make captured logs available to subclasses that need them
+            self._caplog = caplog
 
             # Run local checks
             self.check_build()

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -1,3 +1,5 @@
+import os
+
 from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
 
 
@@ -34,7 +36,7 @@ class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         self.add_figure_environment()
 
         if os.getenv("CI", "false") == "true":
-            get_stdout("python pip install numpy matplotlib", self.cwd, shell=True)
+            get_stdout("python -m pip install numpy matplotlib", self.cwd, shell=True)
 
     def build_local(self):
         super().build_local(args=["--no-conda"])

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -1,0 +1,44 @@
+from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
+
+
+# TODO: Run locally and make sure they both work
+# TODO: Since output is captured, the simplest thing is probably to include a
+# niche package in the environment and test that it compiles with it and does not w/o
+# TODO: Run on CI
+# TODO: Then would also be nice to have a way to compile it without conda and not
+# get an error
+class TestConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """Test that showyourwork creates a conda environment by default"""
+
+    def customize(self):
+        # Add the script to generate the figure
+        self.add_figure_script()
+
+        # Add the figure environment to the tex file
+        self.add_figure_environment()
+
+    def check_build(self):
+        conda_dir = self.cwd / ".snakemake/conda"
+        assert conda_dir.is_dir()
+        assert any(conda_dir.iterdir())
+
+
+class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """Test that the --no-conda flag works"""
+
+    def customize(self):
+        # Add the script to generate the figure
+        self.add_figure_script()
+
+        # Add the figure environment to the tex file
+        self.add_figure_environment()
+
+        if os.getenv("CI", "false") == "true":
+            get_stdout("python pip install numpy matplotlib", self.cwd, shell=True)
+
+    def build_local(self):
+        super().build_local(args=["--no-conda"])
+
+    def check_build(self):
+        conda_dir = self.cwd / ".snakemake/conda"
+        assert not any(conda_dir.iterdir())

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -32,7 +32,11 @@ class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         self.add_figure_environment()
 
         if os.getenv("CI", "false") == "true":
-            get_stdout("mamba install tectonic=0.14.1", cwd=self.cwd, shell=True)
+            get_stdout(
+                "/home/runner/micromamba-bin/micromamba install -y tectonic=0.14.1",
+                cwd=self.cwd,
+                shell=True,
+            )
             get_stdout(
                 "python -m pip install numpy matplotlib", cwd=self.cwd, shell=True
             )

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
 
@@ -32,8 +33,13 @@ class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         self.add_figure_environment()
 
         if os.getenv("CI", "false") == "true":
+            if platform.system() == "Windows":
+                micromamba_path = r" C:\Users\runneradmin\micromamba-bin\micromamba.exe"
+            else:
+                micromamba_path = "/home/runner/micromamba-bin/micromamba"
+
             get_stdout(
-                "/home/runner/micromamba-bin/micromamba install -y tectonic=0.14.1",
+                f"{micromamba_path} install -y tectonic=0.14.1",
                 cwd=self.cwd,
                 shell=True,
             )

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -2,13 +2,9 @@ import os
 
 from helpers import ShowyourworkRepositoryActions, TemporaryShowyourworkRepository
 
+from showyourwork.subproc import get_stdout
 
-# TODO: Run locally and make sure they both work
-# TODO: Since output is captured, the simplest thing is probably to include a
-# niche package in the environment and test that it compiles with it and does not w/o
-# TODO: Run on CI
-# TODO: Then would also be nice to have a way to compile it without conda and not
-# get an error
+
 class TestConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
     """Test that showyourwork creates a conda environment by default"""
 

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -32,7 +32,9 @@ class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         self.add_figure_environment()
 
         if os.getenv("CI", "false") == "true":
-            get_stdout("python -m pip install numpy matplotlib", self.cwd, shell=True)
+            get_stdout(
+                "python -m pip install numpy matplotlib", cwd=self.cwd, shell=True
+            )
 
     def build_local(self):
         super().build_local(args=["--no-conda"])

--- a/tests/integration/test_env.py
+++ b/tests/integration/test_env.py
@@ -32,6 +32,7 @@ class TestNoConda(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions
         self.add_figure_environment()
 
         if os.getenv("CI", "false") == "true":
+            get_stdout("mamba install tectonic=0.14.1", cwd=self.cwd, shell=True)
             get_stdout(
                 "python -m pip install numpy matplotlib", cwd=self.cwd, shell=True
             )


### PR DESCRIPTION
This `--no-conda` flag simply removes the `--use-conda` flag in `run_snakemake()`. It is then up to the user to run `showyourwork` from a properly configured environment with the required package, and to have a working `tectonic` installation.

I still need to update the docs accordingly and add a changelog entry.

Fixes #692. Also related: #114.