### PR TITLE
Improve Zenodo cache creation and repository setup

### DIFF
--- a/docs/changes/694.optimization.rst
+++ b/docs/changes/694.optimization.rst
@@ -1,0 +1,3 @@
+Previously, `showyourwork.yml` always had `cache_on_zenodo: true` by default.
+Now, this is only the case when running `showyourwork setup` with `--cache` or after running `showyourwork cache create`.
+The "Zenodo cache not yet published" warning is also skipped when `cache_on_zenodo` is false.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "graphviz",
     "jinja2",
     "pyyaml",
+    "ruamel.yaml",
     "requests",
     "click",
     "cookiecutter",

--- a/src/showyourwork/cli/commands/setup.py
+++ b/src/showyourwork/cli/commands/setup.py
@@ -272,6 +272,7 @@ def setup(slug, cache, overleaf_id, ssh, action_spec, action_version):
             "repo": repo,
             "name": name,
             "showyourwork_version": __version__,
+            "cache_on_zenodo": cache,
             "cache_sandbox_doi": cache_sandbox_doi,
             "overleaf_id": overleaf_id,
             "year": time.localtime().tm_year,

--- a/src/showyourwork/cli/commands/zenodo.py
+++ b/src/showyourwork/cli/commands/zenodo.py
@@ -1,7 +1,7 @@
 import os
 
 from ... import exceptions, logging
-from ...config import edit_yaml
+from ...config import edit_yaml, edit_yaml_roundtrip
 from ...git import get_repo_branch
 from ...zenodo import Zenodo
 
@@ -136,6 +136,8 @@ def zenodo_create(branch):
         config["cache"] = config.get("cache", {})
         config["cache"][branch] = config["cache"].get(branch, {})
         config["cache"][branch]["sandbox"] = deposit.doi
+    with edit_yaml_roundtrip("showyourwork.yml") as config:
+        config["cache_on_zenodo"] = True
 
 
 def zenodo_delete(branch):

--- a/src/showyourwork/config.py
+++ b/src/showyourwork/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import jinja2
 import yaml
 from packaging import version
+from ruamel.yaml import YAML
 
 from . import __version__, exceptions, git, paths
 
@@ -38,6 +39,20 @@ def edit_yaml(file):
     finally:
         with open(file, "w") as f:
             print(yaml.dump(contents, Dumper=Dumper), file=f)
+
+
+@contextmanager
+def edit_yaml_roundtrip(file):
+    yaml_rt = YAML()
+    yaml_rt.preserve_quotes = True
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+    p = Path(file)
+    data = yaml_rt.load(p.read_text()) if p.exists() else {}
+    try:
+        yield data
+    finally:
+        with open(file, "w") as f:
+            yaml_rt.dump(data, f)
 
 
 def render_config(cwd="."):
@@ -175,14 +190,14 @@ def parse_overleaf():
         config["overleaf"]["push"] = []
     elif not isinstance(config["overleaf"]["push"], list):
         raise exceptions.ConfigError(
-            "Error parsing the config. " "The `overleaf.push` field must be a list."
+            "Error parsing the config. The `overleaf.push` field must be a list."
         )
     config["overleaf"]["pull"] = config["overleaf"].get("pull", [])
     if config["overleaf"]["pull"] is None:
         config["overleaf"]["pull"] = []
     elif not isinstance(config["overleaf"]["pull"], list):
         raise exceptions.ConfigError(
-            "Error parsing the config. " "The `overleaf.pull` field must be a list."
+            "Error parsing the config. The `overleaf.pull` field must be a list."
         )
 
     # Ensure all files in `push` and `pull` are in the `src/tex` directory

--- a/src/showyourwork/cookiecutter-showyourwork/cookiecutter.json
+++ b/src/showyourwork/cookiecutter-showyourwork/cookiecutter.json
@@ -3,6 +3,7 @@
   "repo": null,
   "name": null,
   "showyourwork_version": null,
+  "cache_on_zenodo": true,
   "cache_sandbox_doi": null,
   "overleaf_id": null,
   "year": null,

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/showyourwork.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/showyourwork.yml
@@ -87,7 +87,7 @@ stamp:
     maxlen: 40
 
 # Enable SyncTeX?
-synctex: True
+synctex: true
 
 # Command-line options to be passed to tectonic when building the manuscript
 tectonic_args: []

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/showyourwork.yml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/showyourwork.yml
@@ -1,5 +1,5 @@
 # Enable rule caching on Zenodo?
-cache_on_zenodo: true
+cache_on_zenodo: {{ cookiecutter.cache_on_zenodo | lower }}
 
 # Workflow graph (DAG) generation
 dag:

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -7,7 +7,7 @@ from helpers import (
 )
 
 from showyourwork import exceptions
-from showyourwork.config import edit_yaml
+from showyourwork.config import edit_yaml, edit_yaml_roundtrip
 from showyourwork.subproc import get_stdout
 from showyourwork.zenodo import Zenodo
 
@@ -37,13 +37,73 @@ class TestCache(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
 
         # Make the dataset a dependency of the figure
         with edit_yaml(self.cwd / "showyourwork.yml") as config:
+            cache_is_set = config["cache_on_zenodo"]
             config["dependencies"] = {
                 "src/scripts/test_figure.py": "src/data/test_data.npz"
             }
             config["run_cache_rules_on_ci"] = True
 
+        assert cache_is_set
+
         # Add the figure environment to the tex file
         self.add_figure_environment()
+
+
+class TestCacheCreate(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
+    """
+    Test the creation of a Zenodo cache after creating the repository
+
+    """
+
+    require_local_build = True
+
+    def customize(self):
+        """Add all necessary files for the build."""
+        # Add the pipeline script
+        self.add_pipeline_script()
+
+        # Add the Snakefile rule to generate the dataset
+        self.add_pipeline_rule()
+
+        # Add the script to generate the figure
+        self.add_figure_script(load_data=True)
+
+        # Add the figure environment to the tex file
+        self.add_figure_environment()
+
+        # Make the dataset a dependency of the figure
+        with edit_yaml_roundtrip(self.cwd / "showyourwork.yml") as config:
+            config["dependencies"] = {
+                "src/scripts/test_figure.py": "src/data/test_data.npz"
+            }
+            config["run_cache_rules_on_ci"] = True
+            cache_is_set = config["cache_on_zenodo"]
+
+        # Ensure no cache is set to start with
+        assert not cache_is_set
+
+        # Save for later
+        with open(self.cwd / "showyourwork.yml") as f:
+            lines_pre = f.readlines()
+
+        # Create the cache
+        get_stdout("showyourwork cache create", cwd=self.cwd, shell=True)
+
+        # Test that the roundtrip edit in create worked and did not mess config file
+        with open(self.cwd / "showyourwork.yml") as f:
+            lines_post = f.readlines()
+        assert lines_pre[3:] == lines_post[3:]
+
+        # Test that the cache is now set
+        with edit_yaml_roundtrip(self.cwd / "showyourwork.yml") as config:
+            cache_is_set = config["cache_on_zenodo"]
+        assert cache_is_set
+
+        # Test that the zenodo.yml file was also updated
+        with edit_yaml(self.cwd / "zenodo.yml") as config:
+            cache_sandbox_doi = config["cache"]["main"]["sandbox"]
+        assert cache_sandbox_doi is not None
+        assert len(cache_sandbox_doi.strip()) > 0
 
 
 class TestDirCache(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,42 @@
+import yaml
+
+from showyourwork.config import edit_yaml, edit_yaml_roundtrip
+
+START_YAML = """# Top-level comment
+title: "Example"
+enabled: true
+items:
+  - one
+  - two
+nested:
+  # Nested comment
+  value: 42
+"""
+
+
+def test_edit_yaml_preserves_data(tmp_path):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(START_YAML)
+
+    with edit_yaml(config_file) as config:
+        config["nested"]["value"] = 43
+
+    before = yaml.safe_load(START_YAML)
+    after = yaml.safe_load(config_file.read_text())
+
+    assert after["title"] == before["title"]
+    assert after["enabled"] == before["enabled"]
+    assert after["items"] == before["items"]
+    assert after["nested"]["value"] == 43
+
+
+def test_edit_yaml_roundtrip_preserves_entire_file(tmp_path):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(START_YAML)
+
+    with edit_yaml_roundtrip(config_file) as config:
+        # Dummy change
+        config["nested"]["value"] = 43
+        config["nested"]["value"] = 42
+
+    assert config_file.read_text() == START_YAML

--- a/tests/unit/test_workflow_templates.py
+++ b/tests/unit/test_workflow_templates.py
@@ -54,6 +54,24 @@ def render_and_validate_workflow(
         shutil.rmtree(temp_dir)
 
 
+def render_and_load_showyourwork_config(template_dir, context):
+    temp_dir = tempfile.mkdtemp()
+    try:
+        cookiecutter(
+            template_dir,
+            no_input=True,
+            extra_context=context,
+            output_dir=temp_dir,
+        )
+        repo_name = context["repo"]
+        config_path = os.path.join(temp_dir, repo_name, "showyourwork.yml")
+        assert os.path.exists(config_path), "showyourwork.yml not found!"
+        with open(config_path) as f:
+            return yaml.safe_load(f)
+    finally:
+        shutil.rmtree(temp_dir)
+
+
 class BaseSetupTest:
     """Base class for setup command tests with common functionality."""
 
@@ -146,6 +164,7 @@ def test_build_workflow_valid():
         "repo": "testrepo",
         "name": "Test User",
         "showyourwork_version": "v0.4.3",
+        "cache_on_zenodo": True,
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -167,6 +186,7 @@ def test_build_pull_request_workflow_valid():
         "repo": "testrepo",
         "name": "Test User",
         "showyourwork_version": "v0.4.3",
+        "cache_on_zenodo": True,
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -188,6 +208,7 @@ def test_process_pull_request_workflow_valid():
         "repo": "testrepo",
         "name": "Test User",
         "showyourwork_version": "v0.4.3",
+        "cache_on_zenodo": True,
         "cache_sandbox_doi": "",
         "overleaf_id": None,
         "year": 2025,
@@ -207,6 +228,36 @@ def test_process_pull_request_workflow_valid():
         "v1",
         action_path="showyourwork/showyourwork-action/process-pull-request",
     )
+
+
+def test_showyourwork_config_cache_flag_matches_context():
+    template_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../src/showyourwork/cookiecutter-showyourwork",
+        )
+    )
+    base_context = {
+        "user": "testuser",
+        "repo": "testrepo",
+        "name": "Test User",
+        "showyourwork_version": "v0.4.3",
+        "cache_sandbox_doi": "",
+        "overleaf_id": None,
+        "year": 2025,
+        "action_spec": None,
+        "action_version": "v1",
+    }
+
+    config = render_and_load_showyourwork_config(
+        template_dir, {**base_context, "cache_on_zenodo": True}
+    )
+    assert config["cache_on_zenodo"] is True
+
+    config = render_and_load_showyourwork_config(
+        template_dir, {**base_context, "cache_on_zenodo": False}
+    )
+    assert config["cache_on_zenodo"] is False
 
 
 class TestSetupCommandGitScenarios(BaseSetupTest):


### PR DESCRIPTION
Currently, when the repository is setup without the cache, the `showyourwork.yml` config has `cache_on_zenodo` set to `true` anyway, and there is always a warning about "Zenodo cache not yet published for this repository." when running the build.

This PR fixes both issues by:

1. Throwing the warning only when `cache_on_zenodo` is `true`
2. Updating the cookiecutter template and setup function to set `cache_on_zenodo` to `true` only when `--cache` is passed
3. Updating the `showyourwork cache create` command to edit the `showyourwork.yml` file and set `cache_on_zenodo` to `true.

For point 3, I had to add a dependency, `ruamel.yaml`, so that the `showyourwork.yml` could be edited in place while preserving comments and formatting.

I also added unit tests for `edit_yaml` and `edit_yaml_roundtrip` as well as an integration test where the cache is not set as first and is then created.