### PR TITLE
Make Zenodo caching errors fatal

### DIFF
--- a/docs/changes/695.optimization.rst
+++ b/docs/changes/695.optimization.rst
@@ -1,0 +1,3 @@
+All Zenodo caching errors were treated as non-fatal by showyourwork and printed to the logs.
+Unexpected errors will now be raised and prevent the workflow from completing.
+This should make the interface more predictable and easier to debug.

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -130,6 +130,15 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
     _fetch = LocalOutputFileCache.fetch
     _store = LocalOutputFileCache.store
 
+    def _raise_on_ci(config, outputfile):
+        if config.get("github_actions") and not config.get("run_cache_rules_on_ci"):
+            raise exceptions.ShowyourworkException(
+                f"Cache for {outputfile} not found, and "
+                "`run_cache_rules_on_ci` is set to `False`."
+            )
+        else:
+            logger.warning("Running rule from scratch...")
+
     # Define the patches
     def fetch(self, job, zenodo=zenodo, sandbox=sandbox, _fetch_fn=_fetch):
         # If the cache file is a directory, we must tar it up
@@ -155,27 +164,30 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                         file_exists = True
                         logger.info(f"Restoring from Zenodo cache: {outputfile}...")
                     except exceptions.FileNotFoundOnZenodo:
-                        logger.debug("Searching Zenodo Sandbox cache...")
-                        sandbox.download_file(cachefile, job.rule.name, tarball=tarball)
-                        file_exists = True
-                        logger.info(
-                            f"Restoring from Zenodo Sandbox cache: {outputfile}..."
-                        )
+                        try:
+                            logger.debug("Searching Zenodo Sandbox cache...")
+                            sandbox.download_file(
+                                cachefile, job.rule.name, tarball=tarball
+                            )
+                            file_exists = True
+                            logger.info(
+                                f"Restoring from Zenodo Sandbox cache: {outputfile}..."
+                            )
+                        except exceptions.ZenodoRecordNotFound:
+                            exceptions.restore_trace()
+                            logger.warning(
+                                f"Zenodo sandbox record {sandbox.doi} does not exist. "
+                                "It should probably be removed from zenodo.yml."
+                            )
+                            _raise_on_ci(config, outputfile)
+
                 except exceptions.FileNotFoundOnZenodo:
                     # Cache miss; not fatal
                     exceptions.restore_trace()
                     logger.warning(
                         f"Required version of file not found in cache: {outputfile}."
                     )
-                    if config.get("github_actions") and not config.get(
-                        "run_cache_rules_on_ci"
-                    ):
-                        raise exceptions.ShowyourworkException(
-                            f"Cache for {outputfile} not found, and "
-                            "`run_cache_rules_on_ci` is set to `False`."
-                        )
-                    else:
-                        logger.warning("Running rule from scratch...")
+                    _raise_on_ci(config, outputfile)
             else:
                 # We're good
                 logger.info(f"Restoring from local cache: {outputfile}...")

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -176,25 +176,6 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                         )
                     else:
                         logger.warning("Running rule from scratch...")
-                # TODO: Are there specific cases where we should still skip this?
-                # E.g. user does not haev access to Zenodo?
-                # except Exception as e:
-                #     # NOTE: we treat all Zenodo caching errors as non-fatal
-                #     exceptions.restore_trace()
-                #     logger.warning(
-                #         "File not found on remote cache. See logs for details."
-                #     )
-                #     if len(str(e)):
-                #         logger.debug(str(e))
-                #     if config.get("github_actions") and not config.get(
-                #         "run_cache_rules_on_ci"
-                #     ):
-                #         raise exceptions.ShowyourworkException(
-                #             f"Cache for {outputfile} not found, and "
-                #             "`run_cache_rules_on_ci` is set to `False`."
-                #         )
-                #     else:
-                #         logger.warning("Running rule from scratch...")
             else:
                 # We're good
                 logger.info(f"Restoring from local cache: {outputfile}...")
@@ -207,25 +188,17 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
             # never update the cache
             if file_exists and not snakemake.workflow.config.get("github_actions"):
                 logger.info(f"Syncing file with Zenodo Sandbox cache: {outputfile}...")
-                try:
+                if sandbox.user_is_owner:
                     sandbox.upload_file(
                         cachefile,
                         job.rule.name,
                         tarball=tarball,
                     )
-                # TODO: Remove the try/except if we always raise anyway
-                except Exception as e:
-                    raise e
-                    # TODO: Are there specific cases where we should still skip this?
-                    # E.g. user does not haev access to Zenodo?
-                    # # NOTE: we treate all Zenodo caching errors as non-fatal
-                    # exceptions.restore_trace()
-                    # logger.warning(
-                    #     f"Failed to sync {outputfile} with Zenodo Sandbox cache. "
-                    #     "See logs for details."
-                    # )
-                    # if len(str(e)):
-                    #     logger.debug(str(e))
+                else:
+                    logger.warning(
+                        "The user does not have permission to push"
+                        "to the Zenodo deposit."
+                    )
 
         # Call the original method
         return _fetch_fn(self, job)
@@ -244,21 +217,13 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
 
             for outputfile, cachefile in self.get_outputfiles_and_cachefiles(job):
                 logger.info(f"Caching output file on remote: {outputfile}...")
-                try:
+                if sandbox.user_is_owner:
                     sandbox.upload_file(cachefile, job.rule.name, tarball=tarball)
-                except Exception as e:
-                    # TODO: Remove try/except if not needed
-                    raise e
-                    # NOTE: we treate all Zenodo caching errors as non-fatal
-                    # TODO: Are there specific cases where we should still skip this?
-                    # E.g. user does not haev access to Zenodo?
-                    # exceptions.restore_trace()
-                    # logger.warning(
-                    #     f"Failed to upload {outputfile} to Zenodo Sandbox cache. "
-                    #     "See logs for details."
-                    # )
-                    # if len(str(e)):
-                    #     logger.debug(str(e))
+                else:
+                    logger.warning(
+                        "The user does not have permission to push"
+                        "to the Zenodo deposit."
+                    )
 
         return result
 

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -176,23 +176,25 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                         )
                     else:
                         logger.warning("Running rule from scratch...")
-                except Exception as e:
-                    # NOTE: we treat all Zenodo caching errors as non-fatal
-                    exceptions.restore_trace()
-                    logger.warning(
-                        "File not found on remote cache. See logs for details."
-                    )
-                    if len(str(e)):
-                        logger.debug(str(e))
-                    if config.get("github_actions") and not config.get(
-                        "run_cache_rules_on_ci"
-                    ):
-                        raise exceptions.ShowyourworkException(
-                            f"Cache for {outputfile} not found, and "
-                            "`run_cache_rules_on_ci` is set to `False`."
-                        )
-                    else:
-                        logger.warning("Running rule from scratch...")
+                # TODO: Are there specific cases where we should still skip this?
+                # E.g. user does not haev access to Zenodo?
+                # except Exception as e:
+                #     # NOTE: we treat all Zenodo caching errors as non-fatal
+                #     exceptions.restore_trace()
+                #     logger.warning(
+                #         "File not found on remote cache. See logs for details."
+                #     )
+                #     if len(str(e)):
+                #         logger.debug(str(e))
+                #     if config.get("github_actions") and not config.get(
+                #         "run_cache_rules_on_ci"
+                #     ):
+                #         raise exceptions.ShowyourworkException(
+                #             f"Cache for {outputfile} not found, and "
+                #             "`run_cache_rules_on_ci` is set to `False`."
+                #         )
+                #     else:
+                #         logger.warning("Running rule from scratch...")
             else:
                 # We're good
                 logger.info(f"Restoring from local cache: {outputfile}...")
@@ -211,15 +213,19 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                         job.rule.name,
                         tarball=tarball,
                     )
+                # TODO: Remove the try/except if we always raise anyway
                 except Exception as e:
-                    # NOTE: we treate all Zenodo caching errors as non-fatal
-                    exceptions.restore_trace()
-                    logger.warning(
-                        f"Failed to sync {outputfile} with Zenodo Sandbox cache. "
-                        "See logs for details."
-                    )
-                    if len(str(e)):
-                        logger.debug(str(e))
+                    raise e
+                    # TODO: Are there specific cases where we should still skip this?
+                    # E.g. user does not haev access to Zenodo?
+                    # # NOTE: we treate all Zenodo caching errors as non-fatal
+                    # exceptions.restore_trace()
+                    # logger.warning(
+                    #     f"Failed to sync {outputfile} with Zenodo Sandbox cache. "
+                    #     "See logs for details."
+                    # )
+                    # if len(str(e)):
+                    #     logger.debug(str(e))
 
         # Call the original method
         return _fetch_fn(self, job)
@@ -241,14 +247,18 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                 try:
                     sandbox.upload_file(cachefile, job.rule.name, tarball=tarball)
                 except Exception as e:
+                    # TODO: Remove try/except if not needed
+                    raise e
                     # NOTE: we treate all Zenodo caching errors as non-fatal
-                    exceptions.restore_trace()
-                    logger.warning(
-                        f"Failed to upload {outputfile} to Zenodo Sandbox cache. "
-                        "See logs for details."
-                    )
-                    if len(str(e)):
-                        logger.debug(str(e))
+                    # TODO: Are there specific cases where we should still skip this?
+                    # E.g. user does not haev access to Zenodo?
+                    # exceptions.restore_trace()
+                    # logger.warning(
+                    #     f"Failed to upload {outputfile} to Zenodo Sandbox cache. "
+                    #     "See logs for details."
+                    # )
+                    # if len(str(e)):
+                    #     logger.debug(str(e))
 
         return result
 

--- a/src/showyourwork/userrules.py
+++ b/src/showyourwork/userrules.py
@@ -27,7 +27,6 @@ def process_user_rules():
     # Patch the Snakemake caching functionality so we
     # can cache things on Zenodo
     branch = get_repo_branch()
-    cache_on_zenodo = snakemake.workflow.config["cache_on_zenodo"]
     cache_zenodo_doi = snakemake.workflow.config["cache"][branch]["zenodo"]
     cache_sandbox_doi = snakemake.workflow.config["cache"][branch]["sandbox"]
     cached_deps = []
@@ -35,7 +34,7 @@ def process_user_rules():
         patch_snakemake_cache(cache_zenodo_doi, cache_sandbox_doi)
 
     # Remind the user to publish the deposit
-    if cache_on_zenodo and not cache_zenodo_doi and get_run_type() == "build":
+    if not cache_zenodo_doi and get_run_type() == "build":
         get_logger().warning("Zenodo cache not yet published for this repository.")
 
     # Process each user rule

--- a/src/showyourwork/userrules.py
+++ b/src/showyourwork/userrules.py
@@ -27,6 +27,7 @@ def process_user_rules():
     # Patch the Snakemake caching functionality so we
     # can cache things on Zenodo
     branch = get_repo_branch()
+    cache_on_zenodo = snakemake.workflow.config["cache_on_zenodo"]
     cache_zenodo_doi = snakemake.workflow.config["cache"][branch]["zenodo"]
     cache_sandbox_doi = snakemake.workflow.config["cache"][branch]["sandbox"]
     cached_deps = []
@@ -34,7 +35,7 @@ def process_user_rules():
         patch_snakemake_cache(cache_zenodo_doi, cache_sandbox_doi)
 
     # Remind the user to publish the deposit
-    if not cache_zenodo_doi and get_run_type() == "build":
+    if cache_on_zenodo and not cache_zenodo_doi and get_run_type() == "build":
         get_logger().warning("Zenodo cache not yet published for this repository.")
 
     # Process each user rule

--- a/src/showyourwork/zenodo.py
+++ b/src/showyourwork/zenodo.py
@@ -853,6 +853,8 @@ class Zenodo:
             if "is not registered" in data.get("message", ""):
                 # There is no published record with this id
                 pass
+            elif "persistent identifier does not exist" in data.get("message", ""):
+                raise exceptions.ZenodoRecordNotFound(self.deposit_id)
             else:
                 # Something unexpected happened
                 raise exceptions.ZenodoError(


### PR DESCRIPTION
Currently, all Zenodo caching errors are treated as non-fatal and are printed to the logs. While this makes sense for an unstable implementation, I think it is better if we catch specific errors and let the others be raised. This will make problems with the implementation more explicit, and the interface feels stable enough to do this now I think.

This PR only removes the generic `except Exception as e` in the caching patches. All other except clauses are kept. Also, we only attempt to push to the cache if `sandbox.user_is_owner == True`. Otherwise we print a non-fatal warning. Hopefully this is enough to let users run a workflow that they download on GitHub from someone else. I need to test this.