### PR TITLE
Fix async function calls in caching patches

### DIFF
--- a/docs/changes/697.bugfix.rst
+++ b/docs/changes/697.bugfix.rst
@@ -1,0 +1,2 @@
+Snakemake updates in version 9.18.1 caused showyourwork caching to raise an error.
+Caching code in showyourwork has been updated to work with the latest version of Snakemake.

--- a/docs/changes/697.bugfix.rst
+++ b/docs/changes/697.bugfix.rst
@@ -1,2 +1,3 @@
 Snakemake updates in version 9.18.1 caused showyourwork caching to raise an error.
 Caching code in showyourwork has been updated to work with the latest version of Snakemake.
+Snakemake version `snakemake>=9.18.1` is now required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "click",
     "cookiecutter",
     "packaging",
-    "snakemake>=9.17.3",
+    "snakemake>=9.18.0",
     "pulp",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "click",
     "cookiecutter",
     "packaging",
-    "snakemake>=9.18.0",
+    "snakemake>=9.18.1",
     "pulp",
 ]
 

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -627,7 +627,6 @@ def job_is_cached(job):
     return True
 
 
-# TODO: Test if this and job_is_cached work
 def get_skippable_jobs(dag):
     """
     Search the DAG and return jobs we can safely skip due to

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -231,7 +231,7 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
             logger.warning("Running rule from scratch...")
 
     # Define the patches
-    def fetch(self, job, zenodo=zenodo, sandbox=sandbox, _fetch_fn=_fetch):
+    async def fetch(self, job, zenodo=zenodo, sandbox=sandbox, _fetch_fn=_fetch):
         # If the cache file is a directory, we must tar it up
         # Recall that cacheable jobs can only have a _single_ output
         # (unless using multiext), so checking the first output should suffice
@@ -240,7 +240,7 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
             tarball = True
         else:
             tarball = False
-        for outputfile, cachefile in self.get_outputfiles_and_cachefiles(job):
+        for outputfile, cachefile in await self.get_outputfiles_and_cachefiles(job):
             file_exists = cachefile.exists()
             if not file_exists:
                 # Attempt to download from Zenodo and then Zenodo Sandbox
@@ -304,7 +304,7 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
                     )
 
         # Call the original method
-        return _fetch_fn(self, job)
+        return await _fetch_fn(self, job)
 
     async def store(self, job, sandbox=sandbox, _store_fn=_store):
         # Call the original async method and await it
@@ -318,7 +318,7 @@ def patch_snakemake_cache(zenodo_doi, sandbox_doi):
             else:
                 tarball = False
 
-            for outputfile, cachefile in self.get_outputfiles_and_cachefiles(job):
+            for outputfile, cachefile in await self.get_outputfiles_and_cachefiles(job):
                 logger.info(f"Caching output file on remote: {outputfile}...")
                 if sandbox.user_is_owner:
                     sandbox.upload_file(cachefile, job.rule.name, tarball=tarball)
@@ -553,7 +553,7 @@ def _run_async_safely(coro):
         return asyncio.run(coro)
 
 
-def job_is_cached(job):
+async def job_is_cached(job):
     """
     Return True if a job's outputs will be restored from cache.
 
@@ -597,7 +597,7 @@ def job_is_cached(job):
         return False
 
     # Loop over cache files for the job (should really only be one)
-    for _outputfile, cachefile in cache.get_outputfiles_and_cachefiles(job):
+    for _outputfile, cachefile in await cache.get_outputfiles_and_cachefiles(job):
 
         def _file_exists(cachefile, doi):
             """

--- a/src/showyourwork/patches.py
+++ b/src/showyourwork/patches.py
@@ -553,7 +553,7 @@ def _run_async_safely(coro):
         return asyncio.run(coro)
 
 
-async def job_is_cached(job):
+def job_is_cached(job):
     """
     Return True if a job's outputs will be restored from cache.
 
@@ -597,7 +597,9 @@ async def job_is_cached(job):
         return False
 
     # Loop over cache files for the job (should really only be one)
-    for _outputfile, cachefile in await cache.get_outputfiles_and_cachefiles(job):
+    for _outputfile, cachefile in _run_async_safely(
+        cache.get_outputfiles_and_cachefiles(job)
+    ):
 
         def _file_exists(cachefile, doi):
             """
@@ -625,6 +627,7 @@ async def job_is_cached(job):
     return True
 
 
+# TODO: Test if this and job_is_cached work
 def get_skippable_jobs(dag):
     """
     Search the DAG and return jobs we can safely skip due to


### PR DESCRIPTION
Fixes #696.

- I made `fetch()` async since that was done upstream and added `await`s in it when relevant.
- `store()` was already async so I only had to add an `await`.
- `job_is_cached()` is not async nor are its callers, so I used the `_run_async_safely()` helper for this one.

Instead of handling multiple versions of Snakemake, I felt it was simpler and a reasonable requirement to just enforce `snakemake>=9.18.0`.