### PR TITLE
Enable linting for rule `F821` (undefined names)

### DIFF
--- a/docs/changes/698.maintenance.rst
+++ b/docs/changes/698.maintenance.rst
@@ -1,0 +1,2 @@
+Adds a mention of explcit snakemake imports in the showyourwork documentation.
+Enforces ``snakemake>=9.17.3`` to ensure that the internal snakemake imports work.

--- a/docs/snakefile.rst
+++ b/docs/snakefile.rst
@@ -68,6 +68,23 @@ within the script via the ``snakemake.params`` dictionary
 (e.g., ``snakemake.params["seed"]``). Note that there's
 no need to explicitly import ``snakemake`` within ``run_simulation.py``, as
 it gets automagically inserted into the namespace.
+However, your code editor, linter or type checker may still show an error
+or warning about ``snakemake`` being undefined. To fix this, when using
+``snakemake`` version 9.17.3 or above, you can import it explicitly at the
+top of your script using the following snippet:
+
+.. code-block:: python
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from snakemake.iocontainers import snakemake
+
+For ``snakemake`` versions lower than 9.17.0, the following could be used:
+
+.. code-block:: python
+
+    from snakemake.script import snakemake
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "click",
     "cookiecutter",
     "packaging",
-    "snakemake>=9.17.0",
+    "snakemake>=9.17.3",
     "pulp",
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -39,7 +39,6 @@ target-version = "py39"
 select = ["F", "I", "E", "W", "YTT", "B", "Q", "PLE", "PLR", "PLW", "UP"]
 ignore = [
     "B904",    # Don't require explicit raise ... from in expections for now
-    "F821",    # Allow undefined names (for now!) to handle MAGIC snakemake
     "PLR0912", # Allow more branches
     "PLR0913", # Allow more function arguments
     "PLR0915", # Allow more statements

--- a/src/showyourwork/workflow/scripts/arxiv.py
+++ b/src/showyourwork/workflow/scripts/arxiv.py
@@ -10,6 +10,10 @@ import subprocess
 import tarfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import paths
 

--- a/src/showyourwork/workflow/scripts/compile_setup.py
+++ b/src/showyourwork/workflow/scripts/compile_setup.py
@@ -5,8 +5,12 @@ Compiles the article manuscript into a PDF.
 
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jinja2 import BaseLoader, Environment
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import paths
 

--- a/src/showyourwork/workflow/scripts/copy_and_fix_synctex.py
+++ b/src/showyourwork/workflow/scripts/copy_and_fix_synctex.py
@@ -1,5 +1,9 @@
 import gzip
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import paths
 

--- a/src/showyourwork/workflow/scripts/download.py
+++ b/src/showyourwork/workflow/scripts/download.py
@@ -4,6 +4,10 @@ Downloads a publically available file from a Zenodo or Zenodo Sandbox record.
 """
 
 import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import exceptions
 from showyourwork.logging import get_logger

--- a/src/showyourwork/workflow/scripts/extract.py
+++ b/src/showyourwork/workflow/scripts/extract.py
@@ -7,7 +7,11 @@ import shutil
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from zipfile import ZipFile
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import exceptions
 from showyourwork.logging import get_logger

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -15,7 +15,11 @@ import json
 import re
 from collections.abc import MutableMapping
 from pathlib import Path
+from typing import TYPE_CHECKING
 from xml.etree.ElementTree import parse as ParseXMLTree
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from showyourwork import exceptions, paths, zenodo
 from showyourwork.config import get_upstream_dependencies

--- a/src/showyourwork/workflow/scripts/render_dag.py
+++ b/src/showyourwork/workflow/scripts/render_dag.py
@@ -5,10 +5,14 @@ Generates a directed acyclic graph (DAG) of the build process.
 
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import graphviz
 import pymupdf  # PyMuPDF
 from PIL import Image
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 
 def is_relative_to(path, other):

--- a/src/showyourwork/zenodo.py
+++ b/src/showyourwork/zenodo.py
@@ -346,7 +346,7 @@ class Zenodo:
         return False
 
     @require_access_token
-    def _get_draft(self):
+    def _get_draft(self, rule_name=None):
         """Get the latest draft associated with a deposit or create one
 
         Returns:
@@ -354,6 +354,10 @@ class Zenodo:
         """
         # Logger
         logger = get_logger()
+
+        err_msg = f"{self.service} authentication failed."
+        if rule_name is not None:
+            err_msg += f" Unable to upload cache for rule {rule_name}."
 
         # Check if a draft already exists, and create it if not.
         # If authentication fails, return with a gentle warning
@@ -367,10 +371,7 @@ class Zenodo:
             },
         )
         if r.status_code > 204:
-            logger.warning(
-                f"{self.service} authentication failed. Unable to upload cache for "
-                f"rule {rule_name}."
-            )
+            logger.warning(err_msg)
             try:
                 data = r.json()
             except Exception:
@@ -388,10 +389,7 @@ class Zenodo:
             # latest first
             data = sorted(data, key=lambda x: x.get("modified", ""), reverse=True)
         else:
-            logger.warning(
-                f"{self.service} authentication failed. Unable to upload cache for "
-                f"rule {rule_name}."
-            )
+            logger.warning(err_msg)
             return
 
         # Save an id in case we need to create a new draft
@@ -922,7 +920,7 @@ class Zenodo:
         Upload a file to the latest deposit draft.
 
         """
-        draft = self._get_draft()
+        draft = self._get_draft(rule_name)
 
         self.upload_file_to_draft(draft, file, rule_name, tarball=tarball)
 


### PR DESCRIPTION
The rule was disabled in `ruff.toml` to silence linter errors about `snakemake`. I re-enabled the rules and removed the errors by importing `snakemake` under the `TYPE_CHECKING` condition. The proper way to do this has been updated recently, see https://github.com/snakemake/snakemake/issues/4113 and https://github.com/snakemake/snakemake/pull/4116.

I also updated a missing `rule_name` argument to `_get_draft()`.

I think long term keeping this rule enabled will be beneficial to avoid missing small errors in the codebase.