### PR TITLE
Make dependencies a list, not a string in test_hooks.py

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -48,7 +48,7 @@ class TestHooks(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
         # Make the dataset a dependency of the figure
         with edit_yaml(self.cwd / "showyourwork.yml") as config:
             config["dependencies"] = {
-                "src/scripts/test_figure.py": "src/data/test_data.npz"
+                "src/scripts/test_figure.py": ["src/data/test_data.npz"]
             }
             config["run_cache_rules_on_ci"] = True
 


### PR DESCRIPTION
The specs in the docs is clear that each dependencies entry should point to a list. I had used a string in the tests for #688...

This is what caused the error in #670, sorry about that!

I confirm that merging this into 670 allows me to run `test_hooks.py` and get it to pass.