### PR TITLE
Avoid margin icons to superimpose each other when font size grows

### DIFF
--- a/docs/changes/710.bugfix.rst
+++ b/docs/changes/710.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed margin icons overlapping on large-format documents (e.g. A0 posters)
+and a configurable option ``vertical_offset`` has been added to ``margin_icons`` in
+``showyourwork.yml``.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -526,6 +526,17 @@ Finally, dependencies of the manuscript file are also allowed:
 
 **Required:** no
 
+.. _config.margin_icons.vertical_offset:
+
+``margin_icons.vertical_offset``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``str``
+
+**Description:** A LaTeX length specifying the vertical gap between stacked margin icons (e.g. ``0.5ex``, ``2pt``). The default value ``0.2ex`` uses font-relative units so that spacing scales automatically with the document font size. Increase this value if icons overlap on large-format documents such as posters.
+
+**Required:** no
+
 .. _config.margin_icons.monochrome:
 
 ``margin_icons.monochrome``

--- a/src/showyourwork/config.py
+++ b/src/showyourwork/config.py
@@ -365,6 +365,9 @@ def parse_config():
             config["margin_icons"]["horizontal_offset"] = r"\!" * abs(offset)
         else:
             config["margin_icons"]["horizontal_offset"] = r"\," * offset
+        config["margin_icons"]["vertical_offset"] = config["margin_icons"].get(
+            "vertical_offset", "0.2ex"
+        )
 
         # Preprocessing arXiv tarball settings:
         config["preprocess_arxiv_script"] = config.get("preprocess_arxiv_script", None)

--- a/src/showyourwork/workflow/resources/styles/build.tex
+++ b/src/showyourwork/workflow/resources/styles/build.tex
@@ -125,7 +125,7 @@
 
 % Figure script icon
 \newcommand\syw@Script[1]{%
-  \raisebox{0pt}[6pt][0pt]{%
+  \raisebox{0pt}[0.9ex][0pt]{%
     \href{\syw@url/blob/\syw@sha/\usevalue{#1}}{%
       \color{github-icon}\faGithub%
     }%
@@ -134,7 +134,7 @@
 
 % Figure dataset icon
 \newcommand\syw@DatasetOne[1]{%
-  \raisebox{0pt}[6pt][6pt]{%
+  \raisebox{0pt}[0.9ex][0.9ex]{%
     \href{\usevalue{#1}}{%
       \color{dataset-icon}\faDatabase%
     }%
@@ -143,7 +143,7 @@
 
 % Figure dataset icon
 \newcommand\syw@DatasetTwo[1]{%
-  \raisebox{0pt}[6pt][6pt]{%
+  \raisebox{0pt}[0.9ex][0.9ex]{%
     \href{\usevalue{#1}}{%
       \color{dataset-icon}\faDatabase%
     }%
@@ -152,7 +152,7 @@
 
 % Figure dataset icon
 \newcommand\syw@DatasetThree[1]{%
-  \raisebox{0pt}[6pt][6pt]{%
+  \raisebox{0pt}[0.9ex][0.9ex]{%
     \href{\usevalue{#1}}{%
       \color{dataset-icon}\faDatabase%
     }%
@@ -161,7 +161,7 @@
 
 % Figure cache icon
 \newcommand\syw@Cache[1]{%
-  \raisebox{0pt}[6pt][6pt]{%
+  \raisebox{0pt}[0.9ex][0.9ex]{%
     \IfSubStr*{\usevalue{#1}}{sandbox}{%
       \href{\usevalue{#1}}{%
         \color{sandbox-icon}\faRecycle%
@@ -176,7 +176,7 @@
 
 % Variable script icon: links to a line in the Snakefile
 \newcommand\syw@Variable[1]{%
-  \raisebox{0pt}[6pt][0pt]{%
+  \raisebox{0pt}[0.9ex][0pt]{%
     \href{\syw@url/blob/\syw@sha/\usevalue{#1}}{%
       \color{github-icon}\faGithub%
     }%

--- a/src/showyourwork/workflow/scripts/compile_setup.py
+++ b/src/showyourwork/workflow/scripts/compile_setup.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
 
         \renewcommand\showkeyslabelformat[1]{%
         \normalfont%
-        \setstackgap{S}{0pt}((- margin_icons.horizontal_offset -))
+        \setstackgap{S}{((- margin_icons.vertical_offset -))}%
+        ((- margin_icons.horizontal_offset -))
         \Shortstack[c]{
             \IfEq*{\usevalue{#1_cache}}{KEYNOTFOUND}{}{\syw@Cache{#1_cache}}
             \IfEq*{\usevalue{#1_datasetThree}}{KEYNOTFOUND}{}{\syw@DatasetThree{#1_datasetThree}}


### PR DESCRIPTION
The margin icons (GitHub, dataset, cache) are stacked in figure margins using hardcoded 6pt LaTeX dimensions and a 0pt stack gap. FontAwesome glyphs scale with the document font size, but the bounding boxes don't — so in documents like an A0 poster larger icons will overflow their fixed 6pt boxes and overlap.

This PR fixes this behavior by:

- replacing all hardcoded 6pt `raisebox` dimensions with `0.9ex` (font-relative) in all 6 icon commands (`\syw@Script`, `\syw@DatasetOne/Two/Three`, `\syw@Cache`, `\syw@Variable`). This makes icon bounding boxes scale proportionally with the document font size

- changing `\setstackgap{S}{0pt}` in `compile_setup.py` to use a configurable `vertical_offset` template variable instead of a hardcoded zero gap

- adding the new `vertical_offset` option to the `margin_icons` config section (default: `0.2ex`). Users can override it in `showyourwork.yml`

Closes #708 