### PR TITLE
Refactor tests workflow to use micromamba correctly

### DIFF
--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Install showyourwork
         shell: bash 
         run: |
-          micromamba run -n test-env python -m pip install -U pip
-          micromamba run -n test-env python -m pip install -e ".[tests]"
+          micromamba run -n test-env python -m pip install -U pip --break-system-packages
+          micromamba run -n test-env python -m pip install -e ".[tests]" --break-system-packages
 
       - name: Run local integration tests
         shell: bash

--- a/.github/workflows/local_integration_tests.yml
+++ b/.github/workflows/local_integration_tests.yml
@@ -46,16 +46,16 @@ jobs:
             conda
 
       - name: Set channel priority
-        shell: bash -l {0}
+        shell: bash
         run: |
-          conda config --set channel_priority strict
+          micromamba run -n test-env conda config --set channel_priority strict
 
       - name: Install showyourwork
-        shell: bash -l {0}
+        shell: bash 
         run: |
-          python -m pip install -U pip
-          python -m pip install -e ".[tests]"
+          micromamba run -n test-env python -m pip install -U pip
+          micromamba run -n test-env python -m pip install -e ".[tests]"
 
       - name: Run local integration tests
-        shell: bash -l {0}
-        run: python -m pytest tests/integration
+        shell: bash
+        run: micromamba run -n test-env python -m pytest tests/integration

--- a/.github/workflows/remote_integration_tests.yml
+++ b/.github/workflows/remote_integration_tests.yml
@@ -45,22 +45,21 @@ jobs:
             conda
 
       - name: Set channel priority
-        shell: micromamba-shell {0}
+        shell: bash
         run: |
-          conda config --remove channels defaults || true
-          conda config --add channels conda-forge
-          conda config --set channel_priority strict
+          micromamba run -n test-env conda config --remove channels defaults || true
+          micromamba run -n test-env conda config --add channels conda-forge
+          micromamba run -n test-env conda config --set channel_priority strict
 
       - name: Install showyourwork
-        shell: micromamba-shell {0}
+        shell: bash
         run: |
-          echo $CONDA_PREFIX
-          python -m pip install -U pip
-          python -m pip install 'showyourwork[tests] @ ${{ matrix.showyourwork-spec }}'
+          micromamba run -n test-env python -m pip install -U pip --break-system-packages
+          micromamba run -n test-env python -m pip install 'showyourwork[tests] @ ${{ matrix.showyourwork-spec }}' --break-system-packages
 
       - name: Run remote integration tests
-        shell: micromamba-shell {0}
-        run: python -m pytest --remote -m "remote" tests/integration --action-spec "${{ matrix.showyourwork-spec }}#egg=showyourwork"
+        shell: bash
+        run: micromamba run -n test-env python -m pytest --remote -m "remote" tests/integration --action-spec "${{ matrix.showyourwork-spec }}#egg=showyourwork"
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
           OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,14 +42,14 @@ jobs:
             mamba
 
       - name: Install showyourwork
-        shell: bash -l {0}
+        shell: bash
         run: |
-          python -m pip install -U pip
-          python -m pip install -e ".[tests]"
+          micromamba run -n test-env python -m pip install -U pip --break-system-packages
+          micromamba run -n test-env python -m pip install -e ".[tests]" --break-system-packages
 
       - name: Run tests
-        shell: bash -l {0}
+        shell: bash
         run: |
-          python -m pytest tests/unit
+          micromamba run -n test-env python -m pytest tests/unit 
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}


### PR DESCRIPTION
Updated shell commands to use micromamba for environment management and package installation. Also add --break-system-packages to both pip install commands

See: https://github.com/showyourwork/showyourwork/pull/717#issuecomment-4733227254