### PR TITLE
Update ReadTheDocs config to use Ubuntu 22.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-22.04"
   tools:
     python: "mambaforge-latest"
 


### PR DESCRIPTION
See https://github.com/readthedocs/readthedocs.org/pull/13115

Catched the fail in #719  