### PR TITLE
Use ruff also for formatting, remove black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,17 +5,15 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude_types: [json, binary]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: "26.5.1"
-    hooks:
-      - id: black-jupyter
-        exclude: "^docs/|^tests/projects/"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.22"
+    # Ruff version.
+    rev: v0.16.0
     hooks:
-      - id: ruff
-        exclude: "^docs/|^tests/projects/"
-        args: [--fix, --exit-non-zero-on-fix]
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix, --exit-non-zero-on-fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/snakemake/snakefmt
     rev: v2.0.3
     hooks:

--- a/docs/changes/734.maintenance.rst
+++ b/docs/changes/734.maintenance.rst
@@ -1,1 +1,1 @@
-Both new projects and showyourwork itself are set to use `<ruff https://docs.astral.sh/ruff/>`_ for both linting and formatting.
+Both new projects and showyourwork itself are set to use `ruff <https://docs.astral.sh/ruff/>`_ for both linting and formatting.

--- a/docs/changes/734.maintenance.rst
+++ b/docs/changes/734.maintenance.rst
@@ -1,0 +1,1 @@
+Both new projects and showyourwork itself are set to use `<ruff https://docs.astral.sh/ruff/>`_ for both linting and formatting.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath("."))
 
+import hacks  # ruff: ignore[F401, I001]
+
 
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 if os.environ.get("READTHEDOCS", "") == "True":
@@ -42,7 +44,7 @@ html_logo = "_static/logo.png"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 html_theme_options = {
-    "announcement": "The last release is 2+ years old! For the time being, please use the latest dev version. Stay tuned!",
+    "announcement": "The last release is 2+ years old! For the time being, please use the latest dev version. Stay tuned!",  # ruff: ignore[E501]
     "repository_url": "https://github.com/showyourwork/showyourwork",
     "repository_branch": "main",
     "use_edit_page_button": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath("."))
 
-import hacks
 
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 if os.environ.get("READTHEDOCS", "") == "True":

--- a/docs/hacks.py
+++ b/docs/hacks.py
@@ -145,7 +145,7 @@ if API_KEY is None:
 
 For a complete list of projects linked to other GitHub repositories that make use of showyourwork,
 see `here <https://github.com/showyourwork/showyourwork-action/network/dependents>`__.
-"""
+"""  # noqa: E501
     with open("projects.rst", "w") as f:
         f.write(fallback_content)
 else:

--- a/ruff.toml
+++ b/ruff.toml
@@ -44,6 +44,8 @@ ignore = [
     "PLR0915", # Allow more statements
     "PLR2004", # Allow magic numbers in comparisons
 ]
+[lint.pylint]
+max-positional-args = 8
 
 [lint.isort]
 known-first-party = ["showyourwork"]

--- a/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.pre-commit-config.yaml
+++ b/src/showyourwork/cookiecutter-showyourwork/{{ cookiecutter.repo }}/.pre-commit-config.yaml
@@ -5,18 +5,16 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude_types: [json, binary]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: "26.1.0"
-    hooks:
-      - id: black-jupyter
-        exclude: "^docs/|^tests/projects/"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.14.13"
+    # Ruff version.
+    rev: v0.16.0
     hooks:
-      - id: ruff
-        exclude: "^docs/|^tests/projects/"
-        args: [--fix, --exit-non-zero-on-fix]
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix, --exit-non-zero-on-fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/snakemake/snakefmt
-    rev: v0.11.3
+    rev: v2.0.3
     hooks:
       - id: snakefmt

--- a/src/showyourwork/exceptions/zenodo.py
+++ b/src/showyourwork/exceptions/zenodo.py
@@ -38,9 +38,7 @@ class ZenodoRecordNotFound(ZenodoException):
 
 class InvalidZenodoDOI(ZenodoException):
     def __init__(self, doi):
-        message = (
-            f"The provided `doi` {doi} does " f"not seem to be a valid Zenodo DOI."
-        )
+        message = f"The provided `doi` {doi} does not seem to be a valid Zenodo DOI."
         super().__init__(message)
 
 

--- a/src/showyourwork/overleaf.py
+++ b/src/showyourwork/overleaf.py
@@ -194,7 +194,7 @@ def wipe_remote(project_id, tex=None):
 
     with TemporaryDirectory() as cwd:
         overleaf_token = get_overleaf_credentials()
-        url = f"https://git:{overleaf_token}" f"@git.overleaf.com/{project_id}"
+        url = f"https://git:{overleaf_token}@git.overleaf.com/{project_id}"
         branch = get_remote_branch(url, overleaf_token, cwd=cwd)
         get_stdout(["git", "init"], cwd=cwd)
         get_stdout(["git", "checkout", "-b", branch], cwd=cwd)
@@ -293,7 +293,7 @@ def setup_remote(project_id, path=None):
                 raise Exception()
     except Exception:
         raise exceptions.OverleafError(
-            "Overleaf repository not empty! " "Refusing to rewrite files on remote."
+            "Overleaf repository not empty! Refusing to rewrite files on remote."
         )
     else:
         # Delete the file

--- a/src/showyourwork/workflow/scripts/preprocess.py
+++ b/src/showyourwork/workflow/scripts/preprocess.py
@@ -98,7 +98,7 @@ def parse_datasets():
                 )
             else:
                 raise exceptions.InvalidZenodoIdType(
-                    "Error parsing the config. " f"{doi} is not a valid version DOI."
+                    f"Error parsing the config. {doi} is not a valid version DOI."
                 )
 
         # Deposit contents

--- a/tests/integration/test_directory_dependencies.py
+++ b/tests/integration/test_directory_dependencies.py
@@ -104,9 +104,9 @@ class TestDirectoryDependency(
     def check_build(self):
         """Verify build and that modifying a dependency triggers a rebuild."""
         figure_path = self.cwd / "src" / "tex" / "figures" / "test_figure.pdf"
-        assert (
-            figure_path.exists()
-        ), "Figure was not generated with directory dependencies"
+        assert figure_path.exists(), (
+            "Figure was not generated with directory dependencies"
+        )
 
         # Record the modification time of the generated figure
         mtime_before = figure_path.stat().st_mtime
@@ -122,6 +122,6 @@ class TestDirectoryDependency(
 
         # The figure should have been regenerated
         mtime_after = figure_path.stat().st_mtime
-        assert (
-            mtime_after > mtime_before
-        ), "Figure was not regenerated after modifying a dependency inside a directory"
+        assert mtime_after > mtime_before, (
+            "Figure was not regenerated after modifying a dependency inside a directory"
+        )

--- a/tests/integration/test_overleaf.py
+++ b/tests/integration/test_overleaf.py
@@ -221,6 +221,6 @@ class TestOverleaf(TemporaryShowyourworkRepository, ShowyourworkRepositoryAction
         self.build_local()
 
         # The marker must now be present in the local manuscript
-        assert (
-            marker in ms.read_text()
-        ), "Second build did not pull the new Overleaf changes (issue #603)"
+        assert marker in ms.read_text(), (
+            "Second build did not pull the new Overleaf changes (issue #603)"
+        )

--- a/tests/integration/test_pr.py
+++ b/tests/integration/test_pr.py
@@ -135,7 +135,7 @@ class TestPullRequests(TemporaryShowyourworkRepository):
             elif n < self.action_max_tries - 1:
                 print(
                     f"[{self.repo}] Waiting {self.action_interval} seconds for "
-                    f"PR workflow to finish ({n+2}/{self.action_max_tries})..."
+                    f"PR workflow to finish ({n + 2}/{self.action_max_tries})..."
                 )
                 await asyncio.sleep(self.action_interval)
         else:

--- a/tests/unit/test_workflow_templates.py
+++ b/tests/unit/test_workflow_templates.py
@@ -147,15 +147,15 @@ class BaseSetupTest:
         warning_calls = [
             call.args[0] for call in mock_logger_instance.warning.call_args_list
         ]
-        assert any(
-            expected_text in msg for msg in warning_calls
-        ), f"Expected warning containing '{expected_text}', got: {warning_calls}"
+        assert any(expected_text in msg for msg in warning_calls), (
+            f"Expected warning containing '{expected_text}', got: {warning_calls}"
+        )
 
     def assert_action_spec_in_workflow(self, workflow_content, expected_spec):
         """Assert that the workflow contains the expected action spec."""
-        assert (
-            expected_spec in workflow_content
-        ), f"Expected '{expected_spec}' in workflow content"
+        assert expected_spec in workflow_content, (
+            f"Expected '{expected_spec}' in workflow content"
+        )
 
 
 def test_build_workflow_valid():


### PR DESCRIPTION
Since our tests are created from the _cookiecutter_ template, also that _precommit_ config has been updated accordingly.

Closes #733 