### PR TITLE
[remote tests] Fix remaining ValueErrors related to out-of-repo paths 

### DIFF
--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -131,7 +131,7 @@ class TestDirCache(TemporaryShowyourworkRepository, ShowyourworkRepositoryAction
         # Make the dataset a dependency of the figure
         with edit_yaml(self.cwd / "showyourwork.yml") as config:
             config["dependencies"] = {
-                "src/scripts/test_figure.py": "src/data/test_data"
+                "src/scripts/test_figure.py": ["src/data/test_data"]
             }
             config["run_cache_rules_on_ci"] = True
 

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -39,7 +39,7 @@ class TestCache(TemporaryShowyourworkRepository, ShowyourworkRepositoryActions):
         with edit_yaml(self.cwd / "showyourwork.yml") as config:
             cache_is_set = config["cache_on_zenodo"]
             config["dependencies"] = {
-                "src/scripts/test_figure.py": "src/data/test_data.npz"
+                "src/scripts/test_figure.py": ["src/data/test_data.npz"]
             }
             config["run_cache_rules_on_ci"] = True
 

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -74,7 +74,7 @@ class TestCacheCreate(TemporaryShowyourworkRepository, ShowyourworkRepositoryAct
         # Make the dataset a dependency of the figure
         with edit_yaml_roundtrip(self.cwd / "showyourwork.yml") as config:
             config["dependencies"] = {
-                "src/scripts/test_figure.py": "src/data/test_data.npz"
+                "src/scripts/test_figure.py": ["src/data/test_data.npz"]
             }
             config["run_cache_rules_on_ci"] = True
             cache_is_set = config["cache_on_zenodo"]


### PR DESCRIPTION
This was caused by a few remote tests not yet updated with the hotfix introduced in #706.

Remaining failing remote tests should fail now due to #752, #748.
I expect also #751 